### PR TITLE
Capture issue

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 1.0.0-RC2.2
+version = 1.0.0-RC2.3
 lombokVersion=1.16.2
 joolVersion=0.9.10
 pCollectionsVersion=2.1.2

--- a/src/main/java/com/aol/cyclops/control/FluentFunctions.java
+++ b/src/main/java/com/aol/cyclops/control/FluentFunctions.java
@@ -197,12 +197,13 @@ public class FluentFunctions {
 	 * @param action Consumer
 	 * @return FluentFunction
 	 */
-	public static <T> FluentFunctions.FluentFunction<T,T> expression(Consumer<T> action){
+	public static <T> FluentFunctions.FluentFunction<T,T> expression(Consumer<? super T> action){
 		return FluentFunctions.of(t->{
 			action.accept(t);
 			return t;
 		});
 	}
+	
 	/**
 	 * Convert a checked statement (e.g. a method or Consumer with no return value that throws a Checked Exception) to a 
 	 * fluent expression (FluentFunction).  The input is returned as output
@@ -242,7 +243,7 @@ public class FluentFunctions {
 	 * @param action BiConsumer
 	 * @return FluentBiFunction
 	 */
-	public static <T1,T2> FluentFunctions.FluentBiFunction<T1,T2,Tuple2<T1,T2>> expression(BiConsumer<T1,T2> action){
+	public static <T1,T2> FluentFunctions.FluentBiFunction<T1,T2,Tuple2<T1,T2>> expression(BiConsumer<? super T1,? super T2> action){
 		return FluentFunctions.of((t1,t2)->{
 			action.accept(t1,t2);
 			return Tuple.tuple(t1,t2);

--- a/src/main/java/com/aol/cyclops/control/Ior.java
+++ b/src/main/java/com/aol/cyclops/control/Ior.java
@@ -281,7 +281,12 @@ public interface Ior<ST,PT> extends Supplier<PT>,
 		public Ior<ST, PT> secondaryPeek(Consumer<? super ST> action) {
 			return this;
 		}
-
+		@Override
+		public <R> R visit(Function<? super ST,? extends R> secondary, 
+	            Function<? super PT,? extends R> primary, BiFunction<? super ST, ? super PT, ? extends R> both){	       
+	            return primary.apply(value);
+	    }
+	    
 		@Override
 		public Ior<ST, PT> peek(Consumer<? super PT> action) {
 			action.accept(value);
@@ -477,7 +482,11 @@ public interface Ior<ST,PT> extends Supplier<PT>,
 		public Value<ST> secondaryValue(){
 			return Value.of(()->value);
 		}
-		
+		@Override
+		public <R> R visit(Function<? super ST,? extends R> secondary, 
+	            Function<? super PT,? extends R> primary, BiFunction<? super ST, ? super PT, ? extends R> both){
+	        return swap().visit(secondary,()->null);  
+	    }
 		@Override
 		public boolean isBoth() {
 			return false;
@@ -569,6 +578,14 @@ public interface Ior<ST,PT> extends Supplier<PT>,
 			return Ior.both(primary.swap(), secondary.swap());
 			
 		}
+		@Override
+		public <R> R visit(Function<? super ST,? extends R> secondary, 
+	            Function<? super PT,? extends R> primary, BiFunction<? super ST, ? super PT, ? extends R> both){
+	        
+	        
+	        return Matchable.from(both().get()).visit((a,b)-> both.apply(a, b));
+	    }
+		
 		@Override
 		public Optional<Tuple2<ST, PT>> both() {
 			return Optional.of(Tuple.tuple(secondary.secondaryGet(),primary.get()));

--- a/src/main/java/com/aol/cyclops/control/Xor.java
+++ b/src/main/java/com/aol/cyclops/control/Xor.java
@@ -163,13 +163,8 @@ public interface Xor<ST,PT> extends Supplier<PT>,Value<PT>,Functor<PT>, Filterab
 	public static <ST,PT> Xor<?,ST> accumulateSecondary(CollectionX<Xor<ST,PT>> xors,Semigroup<ST> reducer){
 			return sequenceSecondary(xors).map(s->s.reduce(reducer.reducer()).get());
 	}
-	default <R> R visit(Function<? super ST,? extends R> secondary, 
-            Function<? super PT,? extends R> primary){
-	    
-        if(isSecondary())
-            return swap().visit(secondary,()->null);
-        return visit(primary,()->null);
-    }
+	<R> R visit(Function<? super ST,? extends R> secondary, 
+            Function<? super PT,? extends R> primary);
 	
 	default <R1,R2> Xor<R1,R2> visitXor(Function<? super ST,? extends R1> secondary, 
 			Function<? super PT,? extends R2> primary){
@@ -356,7 +351,11 @@ public interface Xor<ST,PT> extends Supplier<PT>,Value<PT>,Functor<PT>, Filterab
         public Ior<ST, PT> toIor() {
            return Ior.primary(value);
         }
-
+        @Override
+        public <R> R visit(Function<? super ST,? extends R> secondary, 
+                Function<? super PT,? extends R> primary){
+            return primary.apply(value);
+        }
         @Override
         public <R> Eval<R> matches(
                 Function<com.aol.cyclops.control.Matchable.CheckValue1<ST, R>, com.aol.cyclops.control.Matchable.CheckValue1<ST, R>> secondary,
@@ -454,6 +453,11 @@ public interface Xor<ST,PT> extends Supplier<PT>,Value<PT>,Functor<PT>, Filterab
 			stAction.accept(value);
 			
 		}
+		@Override
+        public <R> R visit(Function<? super ST,? extends R> secondary, 
+                Function<? super PT,? extends R> primary){
+            return secondary.apply(value);
+        }
 		
 		public Maybe<PT> toMaybe(){
 			return Maybe.none();

--- a/src/main/java/com/aol/cyclops/internal/react/SimpleReactStreamImpl.java
+++ b/src/main/java/com/aol/cyclops/internal/react/SimpleReactStreamImpl.java
@@ -44,7 +44,9 @@ public class SimpleReactStreamImpl<U> implements SimpleReactStream<U>,EagerToQue
 		Stream s = stream;
 		
 		
-		this.errorHandler = Optional.of((e) -> log.error(e.getMessage(), e));
+		this.errorHandler = Optional.of((e) -> {
+		    log.error(e.getMessage(), e);
+		});
 		this.lastActive = new EagerStreamWrapper(s,this.errorHandler);
 		this.queueFactory = QueueFactories.unboundedQueue();
 		this.subscription = new AlwaysContinue();

--- a/src/main/java/com/aol/cyclops/internal/react/SimpleReactStreamImpl.java
+++ b/src/main/java/com/aol/cyclops/internal/react/SimpleReactStreamImpl.java
@@ -42,9 +42,10 @@ public class SimpleReactStreamImpl<U> implements SimpleReactStream<U>,EagerToQue
 	public SimpleReactStreamImpl(final SimpleReact simpleReact, final Stream<CompletableFuture<U>> stream) {
 		this.simpleReact = simpleReact;
 		Stream s = stream;
-		this.lastActive = new EagerStreamWrapper(s);
+		
 		
 		this.errorHandler = Optional.of((e) -> log.error(e.getMessage(), e));
+		this.lastActive = new EagerStreamWrapper(s,this.errorHandler);
 		this.queueFactory = QueueFactories.unboundedQueue();
 		this.subscription = new AlwaysContinue();
 		

--- a/src/main/java/com/aol/cyclops/internal/react/stream/EagerStreamWrapper.java
+++ b/src/main/java/com/aol/cyclops/internal/react/stream/EagerStreamWrapper.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -68,7 +67,7 @@ public class EagerStreamWrapper implements StreamWrapper {
 	}
 	static  List<CompletableFuture> collect(Stream<CompletableFuture> stream,Collector c,Optional<Consumer<Throwable>> errorHandler){
 	   
-	    Function<Throwable,Object> captureFn = t->{BlockingStreamHelper.captureUnwrap((CompletionException)t, errorHandler); throw ExceptionSoftener.throwSoftenedException(t);};
+	    Function<Throwable,Object> captureFn = t->{BlockingStreamHelper.captureUnwrap(t, errorHandler); throw ExceptionSoftener.throwSoftenedException(t);};
 	    if(errorHandler.isPresent())
 	        return (List<CompletableFuture>)stream
 	                                .map(cf->cf.exceptionally(captureFn))

--- a/src/main/java/com/aol/cyclops/internal/react/stream/EagerStreamWrapper.java
+++ b/src/main/java/com/aol/cyclops/internal/react/stream/EagerStreamWrapper.java
@@ -1,20 +1,22 @@
 package com.aol.cyclops.internal.react.stream;
 
-import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.experimental.Wither;
-
 import com.aol.cyclops.control.SimpleReact;
+import com.aol.cyclops.types.futurestream.BlockingStreamHelper;
 import com.aol.cyclops.types.futurestream.SimpleReactStream;
+
+import lombok.AllArgsConstructor;
+import lombok.experimental.Wither;
 
 @Wither
 @AllArgsConstructor
@@ -23,41 +25,63 @@ public class EagerStreamWrapper implements StreamWrapper {
 	private final List<CompletableFuture> list;
 	private final Stream<CompletableFuture> stream;
 	private final AsyncList async;
+	private final Optional<Consumer<Throwable>> errorHandler;
 
-	public EagerStreamWrapper(List<CompletableFuture> list) {
+	
+	public EagerStreamWrapper(List<CompletableFuture> list,Optional<Consumer<Throwable>> errorHandler) {
 		this.list = list;
 		this.stream = null;
-
+		this.errorHandler = errorHandler;
 		async = null;
 	}
 
-	public EagerStreamWrapper(AsyncList async) {
+	public EagerStreamWrapper(AsyncList async,Optional<Consumer<Throwable>> errorHandler) {
 		this.list = null;
 		this.stream = null;
 		this.async = async;
-
+		this.errorHandler = errorHandler;
 	}
 
-	public EagerStreamWrapper(Stream<CompletableFuture> stream) {
+	public EagerStreamWrapper(Stream<CompletableFuture> stream,Optional<Consumer<Throwable>> errorHandler) {
 		this.stream = stream;
 
-		list = stream.collect(Collectors.toList());
-
+		list = collect(stream,Collectors.toList(),errorHandler);
+		this.errorHandler = errorHandler;
 		async = null;
 
 	}
 
-	public EagerStreamWrapper(Stream<CompletableFuture> stream, Collector c) {
+	public EagerStreamWrapper(Stream<CompletableFuture> stream, Collector c,Optional<Consumer<Throwable>> errorHandler) {
 		this.stream = stream;
 		async = null;
-
-		list = (List<CompletableFuture>) stream.collect(c);
+		this.errorHandler = errorHandler;
+		list =  collect(stream,c,errorHandler);
 
 	}
+	public EagerStreamWrapper collect(){
+	    if(list!=null)
+	        return new EagerStreamWrapper(list.stream(),this.errorHandler);
+	    return new EagerStreamWrapper(stream,this.errorHandler);
+	}
+	static  List<CompletableFuture> collect(Stream<CompletableFuture> stream,Collector c,Optional<Consumer<Throwable>> errorHandler){
+	   
+	    Function<Throwable,Object> captureFn = t->{BlockingStreamHelper.captureUnwrap((CompletionException)t, errorHandler); return null;};
+	    if(errorHandler.isPresent())
+	        return size((List<CompletableFuture>)stream
+	                                .map(cf->cf.exceptionally(captureFn)).filter(cf->!cf.isCompletedExceptionally()).collect(c));
+	   
+	    return size((List<CompletableFuture>)stream.filter(cf->cf.isCompletedExceptionally()).collect(c));
+       
+	}
 
-	public EagerStreamWrapper(CompletableFuture cf) {
+	static List<CompletableFuture> size(List<CompletableFuture> in){
+	    
+	    return in;
+	}
+	public EagerStreamWrapper(CompletableFuture cf,Optional<Consumer<Throwable>> errorHandler) {
 		async = null;
-		list = Arrays.asList(cf);
+		list = collect(Stream.of(cf),Collectors.toList(),errorHandler);
+		this.errorHandler = errorHandler;
 		stream = null;
 
 	}
@@ -66,15 +90,15 @@ public class EagerStreamWrapper implements StreamWrapper {
 			SimpleReact simple) {
 
 		return new EagerStreamWrapper(new AsyncList(stream,
-				simple.getQueueService()));
+				simple.getQueueService()),this.errorHandler);
 	}
 
 	public EagerStreamWrapper stream(
 			Function<Stream<CompletableFuture>, Stream<CompletableFuture>> action) {
 		if (async != null)
-			return new EagerStreamWrapper(async.stream(action));
+			return new EagerStreamWrapper(async.stream(action),this.errorHandler);
 		else
-			return new EagerStreamWrapper(action.apply(list.stream()));
+			return new EagerStreamWrapper(action.apply(list.stream()),this.errorHandler);
 
 	}
 

--- a/src/main/java/com/aol/cyclops/react/SimpleReactFailedStageException.java
+++ b/src/main/java/com/aol/cyclops/react/SimpleReactFailedStageException.java
@@ -1,5 +1,8 @@
 package com.aol.cyclops.react;
 
+import com.aol.cyclops.control.Xor;
+import com.aol.cyclops.control.Matchable.MXor;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -14,5 +17,11 @@ public class SimpleReactFailedStageException extends RuntimeException {
 	
 	public<T>  T getValue(){
 		return (T)value;
+	}
+	
+	public static MXor<Throwable,SimpleReactFailedStageException> matchable(Throwable t){
+	    Xor<Throwable,SimpleReactFailedStageException> error = (t instanceof SimpleReactFailedStageException) ? 
+	                                                            Xor.primary((SimpleReactFailedStageException)t) : Xor.secondary(t);
+	    return ()->error;
 	}
 }

--- a/src/main/java/com/aol/cyclops/types/Convertable.java
+++ b/src/main/java/com/aol/cyclops/types/Convertable.java
@@ -60,9 +60,7 @@ public interface Convertable<T> extends Iterable<T>, Supplier<T>{
 	public T get();
 	
 	
-	default <R> R visit(Function<? super T,? extends R> present,Supplier<? extends R> absent){
-		return Maybe.fromOptional(toOptional()).visit(present, absent);
-	}
+	
 	
 	
 	default T orElseGet(Supplier<? extends T> value){

--- a/src/main/java/com/aol/cyclops/types/Value.java
+++ b/src/main/java/com/aol/cyclops/types/Value.java
@@ -58,7 +58,9 @@ public interface Value<T> extends Supplier<T>,
     
    
    
-    
+    default <R> R visit(Function<? super T,? extends R> present,Supplier<? extends R> absent){
+        return toMaybe().visit(present, absent);
+    }
 
     default boolean test(T t){
         if(!(t instanceof Value))

--- a/src/main/java/com/aol/cyclops/types/futurestream/BaseSimpleReactStream.java
+++ b/src/main/java/com/aol/cyclops/types/futurestream/BaseSimpleReactStream.java
@@ -445,7 +445,7 @@ public interface BaseSimpleReactStream<U> extends BlockingStream<U>{
 	 *         the dataflow
 	 */
 	@SuppressWarnings("unchecked")
-	BaseSimpleReactStream<U> capture(final Consumer<? extends Throwable> errorHandler);
+	BaseSimpleReactStream<U> capture(final Consumer<Throwable> errorHandler);
 	
 	
 

--- a/src/main/java/com/aol/cyclops/types/futurestream/BlockingStreamHelper.java
+++ b/src/main/java/com/aol/cyclops/types/futurestream/BlockingStreamHelper.java
@@ -49,8 +49,13 @@ public class BlockingStreamHelper {
 		return (R) completedFutures.stream().map(next -> getSafe(next,errorHandler))
 				.filter(v -> v != MissingValue.MISSING_VALUE).collect(collector);
 	}
-	public static void captureUnwrap(CompletionException e,Optional<Consumer<Throwable>> errorHandler){
-	    capture(e.getCause(),errorHandler);
+	public static void captureUnwrap(Throwable e,Optional<Consumer<Throwable>> errorHandler){
+	    if(e instanceof  SimpleReactFailedStageException)
+	        captureFailedStage((SimpleReactFailedStageException)e,errorHandler);
+	    else if(e.getCause()!=null)
+	        capture(e.getCause(),errorHandler);
+	    else
+	        captureGeneral(e,errorHandler);
 	}
 	static void capture(final Throwable t,Optional<Consumer<Throwable>> errorHandler) {
 	    SimpleReactFailedStageException.matchable(t)

--- a/src/main/java/com/aol/cyclops/types/futurestream/BlockingStreamHelper.java
+++ b/src/main/java/com/aol/cyclops/types/futurestream/BlockingStreamHelper.java
@@ -3,15 +3,19 @@ package com.aol.cyclops.types.futurestream;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
 
 import com.aol.cyclops.internal.react.async.future.FastFuture;
 import com.aol.cyclops.internal.react.exceptions.FilteredExecutionPathException;
+import com.aol.cyclops.internal.react.exceptions.SimpleReactCompletionException;
 import com.aol.cyclops.internal.react.stream.EagerStreamWrapper;
 import com.aol.cyclops.internal.react.stream.LazyStreamWrapper;
 import com.aol.cyclops.internal.react.stream.MissingValue;
+import com.aol.cyclops.react.SimpleReactFailedStageException;
 import com.aol.cyclops.util.ExceptionSoftener;
 
 public class BlockingStreamHelper {
@@ -45,19 +49,35 @@ public class BlockingStreamHelper {
 		return (R) completedFutures.stream().map(next -> getSafe(next,errorHandler))
 				.filter(v -> v != MissingValue.MISSING_VALUE).collect(collector);
 	}
-	
-	static void capture(final Exception e,Optional<Consumer<Throwable>> errorHandler) {
+	public static void captureUnwrap(CompletionException e,Optional<Consumer<Throwable>> errorHandler){
+	    capture(e.getCause(),errorHandler);
+	}
+	static void capture(final Throwable t,Optional<Consumer<Throwable>> errorHandler) {
+	    SimpleReactFailedStageException.matchable(t)
+	                                   .visit(general-> captureGeneral(general,errorHandler),
+	                                           sr-> captureFailedStage(sr,errorHandler));
+	}
+	static Void captureFailedStage(final SimpleReactFailedStageException e,Optional<Consumer<Throwable>> errorHandler) {
 		errorHandler.ifPresent((handler) -> {
+		   
 			if (!(e.getCause() instanceof FilteredExecutionPathException)) {
 				handler.accept(e.getCause());
 			}
 		});
+		return null;
 	}
+	static Void captureGeneral(final Throwable t,Optional<Consumer<Throwable>> errorHandler) {
+        errorHandler.ifPresent((handler) ->  handler.accept(t.getCause()));
+        return null;
+    }
 	@SuppressWarnings("rawtypes")
 	public static Object getSafe(final FastFuture next,Optional<Consumer<Throwable>> errorHandler) {
 		try {
 			return next.join();
-		} catch (RuntimeException e) {
+		}catch (SimpleReactCompletionException e) {
+            capture(e.getCause(),errorHandler);
+        } 
+		catch (RuntimeException e) {
 			capture(e,errorHandler);
 		} catch (Exception e) {
 			capture(e,errorHandler);
@@ -69,7 +89,9 @@ public class BlockingStreamHelper {
 	static Object getSafe(final CompletableFuture next,Optional<Consumer<Throwable>> errorHandler) {
 		try {
 			return next.get();
-		} catch (InterruptedException e) {
+		}catch(ExecutionException e){
+		    capture(e.getCause(),errorHandler);
+		}catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 			capture(e,errorHandler);
 			throw ExceptionSoftener.throwSoftenedException(e);

--- a/src/main/java/com/aol/cyclops/types/futurestream/BlockingStreamHelper.java
+++ b/src/main/java/com/aol/cyclops/types/futurestream/BlockingStreamHelper.java
@@ -67,7 +67,9 @@ public class BlockingStreamHelper {
 		return null;
 	}
 	static Void captureGeneral(final Throwable t,Optional<Consumer<Throwable>> errorHandler) {
-        errorHandler.ifPresent((handler) ->  handler.accept(t.getCause()));
+	    if(t instanceof FilteredExecutionPathException)
+	        return null;
+        errorHandler.ifPresent((handler) ->  handler.accept(t));
         return null;
     }
 	@SuppressWarnings("rawtypes")

--- a/src/main/java/com/aol/cyclops/types/futurestream/LazyFutureStream.java
+++ b/src/main/java/com/aol/cyclops/types/futurestream/LazyFutureStream.java
@@ -1455,7 +1455,7 @@ public interface LazyFutureStream<U> extends  Functor<U>,
      */
     @Override
     default LazyFutureStream<U> capture(
-            final Consumer<? extends Throwable> errorHandler) {
+            final Consumer<Throwable> errorHandler) {
         return (LazyFutureStream) LazySimpleReactStream.super.capture(errorHandler);
     }
 

--- a/src/main/java/com/aol/cyclops/types/futurestream/LazyFutureStream.java
+++ b/src/main/java/com/aol/cyclops/types/futurestream/LazyFutureStream.java
@@ -97,7 +97,7 @@ import lombok.val;
  *
  */
 
-public interface LazyFutureStream<U> extends  Functor<U>,
+public interface LazyFutureStream<U> extends Functor<U>,
                                             Filterable<U>,   
                                             LazySimpleReactStream<U>,
                                             LazyStream<U>,

--- a/src/main/java/com/aol/cyclops/types/futurestream/LazySimpleReactStream.java
+++ b/src/main/java/com/aol/cyclops/types/futurestream/LazySimpleReactStream.java
@@ -499,7 +499,7 @@ public interface LazySimpleReactStream<U> extends
 	 *         the dataflow
 	 */
 	@SuppressWarnings("unchecked")
-	default LazySimpleReactStream<U> capture(final Consumer<? extends Throwable> errorHandler) {
+	default LazySimpleReactStream<U> capture(final Consumer<Throwable> errorHandler) {
 		return this.withErrorHandler(Optional
 				.of((Consumer<Throwable>) errorHandler));
 	}

--- a/src/main/java/com/aol/cyclops/types/futurestream/SimpleReactStream.java
+++ b/src/main/java/com/aol/cyclops/types/futurestream/SimpleReactStream.java
@@ -79,6 +79,10 @@ public interface SimpleReactStream<U> extends BaseSimpleReactStream<U>,
     default SimpleReactStream<U> self(Consumer<SimpleReactStream<U>> consumer) {
         return peek(n->consumer.accept(this));
     }
+    
+    default void run(){
+        getLastActive().collect();
+    }
     /**
      * Split a stream at a given position. (Operates on futures)
      * <pre>
@@ -980,6 +984,7 @@ public interface SimpleReactStream<U> extends BaseSimpleReactStream<U>,
             .block();
             }
         </pre>
+       
      *
      * In this case, strings will only contain the two successful results (for
      * ()-&gt;1 and ()-&gt;3), an exception for the chain starting from Supplier
@@ -995,7 +1000,7 @@ public interface SimpleReactStream<U> extends BaseSimpleReactStream<U>,
      */
     @SuppressWarnings("unchecked")
     default SimpleReactStream<U> capture(final Consumer<Throwable> errorHandler) {
-        return this.withLastActive(this.getLastActive().withErrorHandler(Optional.of(errorHandler)).collect())
+        return this.withLastActive(this.getLastActive().withErrorHandler(Optional.of(errorHandler)))
                 .withErrorHandler(Optional
                 .of((Consumer<Throwable>) errorHandler));
     }

--- a/src/test/java/com/aol/cyclops/react/base/BaseSeqTest.java
+++ b/src/test/java/com/aol/cyclops/react/base/BaseSeqTest.java
@@ -460,7 +460,7 @@ public abstract class BaseSeqTest {
 	    			.cast(Integer.class)
 	    				.peek(it ->System.out.println(it)).toList();
 	    	
-	    	assertThat(ex.getCause().getClass(),equalTo(ClassCastException.class));
+	    	assertThat(ex.getClass(),equalTo(ClassCastException.class));
 	    }
 	    @Test
 	    public void testCastExceptionOnFail() {

--- a/src/test/java/com/aol/cyclops/react/base/BaseSequentialSeqTest.java
+++ b/src/test/java/com/aol/cyclops/react/base/BaseSequentialSeqTest.java
@@ -450,7 +450,7 @@ public abstract class BaseSequentialSeqTest {
 	    			.cast(Integer.class)
 	    				.peek(it ->System.out.println(it)).toList();
 	    	
-	    	assertThat(ex.getCause().getClass(),equalTo(ClassCastException.class));
+	    	assertThat(ex.getClass(),equalTo(ClassCastException.class));
 	    }
 	    @Test
 	    public void testCastExceptionOnFail() {

--- a/src/test/java/com/aol/cyclops/react/simple/AllOfTest.java
+++ b/src/test/java/com/aol/cyclops/react/simple/AllOfTest.java
@@ -85,7 +85,7 @@ public class AllOfTest {
 	public void testAllOfCompletableFilter(){
 		List<String> urls = Arrays.asList("hello","world","2");
 		List<String> result = new SimpleReact().fromStream(urls.stream()
-				.<CompletableFuture<String>>map(it ->  handle(it)))
+				.map(it ->  handle(it)))
 				.onFail(it ->"hello")
 				.filter(it-> !"2".equals(it))
 				.capture(e -> 
@@ -96,6 +96,7 @@ public class AllOfTest {
 					System.out.println(data);
 						return data; }).block().firstValue();
 		
+		System.out.println(result);
 		assertThat(result.size(),is(2));
 		assertThat(result,hasItem("hello"));
 		assertThat(result,hasItem("world"));

--- a/src/test/java/com/aol/cyclops/react/simple/BlockingTest.java
+++ b/src/test/java/com/aol/cyclops/react/simple/BlockingTest.java
@@ -2,12 +2,13 @@ package com.aol.cyclops.react.simple;
 
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
@@ -142,11 +143,11 @@ public class BlockingTest {
 		assertThat(results.size(), is(0));
 		assertThat(error[0], instanceOf(RuntimeException.class));
 	}
-	volatile int count =0;
+	AtomicInteger count = new AtomicInteger(0);
 	@Test
 	public void testBreakoutExceptionTimes() throws InterruptedException,
 			ExecutionException {
-		count =0;
+	    count = new AtomicInteger(0);
 		List<Integer> results = new SimpleReact()
 				.<Integer> ofAsync(() -> 1, () -> 2, () -> 3)
 				.then(it -> it * 100)
@@ -154,16 +155,16 @@ public class BlockingTest {
 
 					throw new RuntimeException("boo!");
 
-				}).capture(e -> count++)
+				}).capture(e -> count.incrementAndGet())
 				.block(status -> status.getCompleted() >= 1);
 
 		assertThat(results.size(), is(0));
-		assertThat(count, is(3));
+		assertThat(count.get(), is(3));
 	}
 	@Test
 	public void testBreakoutAllCompleted() throws InterruptedException,
 			ExecutionException {
-		count =0;
+	    count = new AtomicInteger(0);
 		List<Integer> results = new SimpleReact()
 				.<Integer> ofAsync(() -> 1, () -> 2, () -> 3)
 				.then(it -> it * 100)
@@ -174,16 +175,16 @@ public class BlockingTest {
 						sleep(it);
 					return it;
 
-				}).capture(e -> count++)
+				}).capture(e -> count.incrementAndGet())
 				.block(status -> status.getAllCompleted() >0);
 
 		assertThat(results.size(), is(0));
-		assertThat(count, is(1));
+		assertThat(count.get(), is(1));
 	}
 	@Test
 	public void testBreakoutAllCompletedStrings() throws InterruptedException,
 			ExecutionException {
-		count =0;
+		count = new AtomicInteger(0);
 		List<String> strings = new SimpleReact()
 				.<Integer> ofAsync(() -> 1, () -> 2, () -> 3)
 				.then(it -> it * 100)
@@ -194,17 +195,18 @@ public class BlockingTest {
 						sleep(it);
 					return it;
 
-				}).capture(e -> count++)
+				})
 				.then( it -> "*" + it)
+				.capture(e -> count.incrementAndGet())
 				.block(status -> status.getAllCompleted() >0);
 
 		assertThat(strings.size(), is(0));
-		assertThat(count, is(1));
+		assertThat(count.get(), is(1));
 	}
 	@Test
 	public void testBreakoutAllCompletedAndTime() throws InterruptedException,
 			ExecutionException {
-			count =0;
+	        count = new AtomicInteger(0);
 			List<Integer> result = new SimpleReact()
 					.<Integer> ofAsync(() -> 1, () -> 2, () -> 3)
 					.then(it -> it * 100)
@@ -212,11 +214,11 @@ public class BlockingTest {
 						sleep(it);
 						return it;
 	
-					}).capture(e -> count++)
+					}).capture(e -> count.incrementAndGet())
 					.block(status -> status.getAllCompleted() >1 && status.getElapsedMillis()>20);
 	
 			assertThat(result.size(), is(2));
-			assertThat(count, is(0));
+			assertThat(count.get(), is(0));
 	}
 	
 

--- a/src/test/java/com/aol/cyclops/react/simple/CaptureTest.java
+++ b/src/test/java/com/aol/cyclops/react/simple/CaptureTest.java
@@ -21,7 +21,8 @@ public class CaptureTest {
                          .peek(System.out::println)
                          .then(this::exception)
                          .peek(System.out::println)
-                         .then(s->"hello"+s);
+                         .then(s->"hello"+s)
+                         .run();
                          
         Thread.sleep(500);                 
         assertNotNull(t);
@@ -36,7 +37,8 @@ public class CaptureTest {
                          .peek(System.out::println)
                          .peek(System.out::println)
                          .then(s->"hello"+s)
-                         .then(this::exception);
+                         .then(this::exception)
+                         .run();
         
                          
         Thread.sleep(500);                 
@@ -50,12 +52,13 @@ public class CaptureTest {
         t=null;
         second =null;
         new SimpleReact().of("hello","world")
+                          .capture(e->t=e)
                          .peek(System.out::println)
                          .then(this::exception)
                          .peek(System.out::println)
                          .capture(e->second=t)
                          .then(s->"hello"+s)
-                         .capture(e->t=e);
+                         .run();
                          
         Thread.sleep(500);                 
         assertNotNull(t);

--- a/src/test/java/com/aol/cyclops/react/simple/CaptureTest.java
+++ b/src/test/java/com/aol/cyclops/react/simple/CaptureTest.java
@@ -46,26 +46,8 @@ public class CaptureTest {
         assertFalse(t.toString(),t instanceof SimpleReactFailedStageException);
         assertTrue(t.toString(),t instanceof InternalException);
     }
-    Throwable second = null;
-    @Test
-    public void captureErrorOnce() throws InterruptedException{
-        t=null;
-        second =null;
-        new SimpleReact().of("hello","world")
-                          .capture(e->t=e)
-                         .peek(System.out::println)
-                         .then(this::exception)
-                         .peek(System.out::println)
-                         .capture(e->second=t)
-                         .then(s->"hello"+s)
-                         .run();
-                         
-        Thread.sleep(500);                 
-        assertNotNull(t);
-        assertNull(second);
-        assertFalse(t.toString(),t instanceof SimpleReactFailedStageException);
-        assertTrue(t.toString(),t instanceof InternalException);
-    }
+    
+    
     @Test
     public void captureBlock(){
         t=null;

--- a/src/test/java/com/aol/cyclops/react/simple/CaptureTest.java
+++ b/src/test/java/com/aol/cyclops/react/simple/CaptureTest.java
@@ -50,12 +50,12 @@ public class CaptureTest {
         t=null;
         second =null;
         new SimpleReact().of("hello","world")
-                         .capture(e->t=e)
                          .peek(System.out::println)
                          .then(this::exception)
                          .peek(System.out::println)
                          .capture(e->second=t)
-                         .then(s->"hello"+s);
+                         .then(s->"hello"+s)
+                         .capture(e->t=e);
                          
         Thread.sleep(500);                 
         assertNotNull(t);

--- a/src/test/java/com/aol/cyclops/react/simple/CaptureTest.java
+++ b/src/test/java/com/aol/cyclops/react/simple/CaptureTest.java
@@ -2,6 +2,8 @@ package com.aol.cyclops.react.simple;
 
 import static org.junit.Assert.*;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.Test;
 
 import com.aol.cyclops.control.LazyReact;
@@ -46,8 +48,21 @@ public class CaptureTest {
         assertFalse(t.toString(),t instanceof SimpleReactFailedStageException);
         assertTrue(t.toString(),t instanceof InternalException);
     }
-    
-    
+    AtomicInteger count;
+    @Test
+    public void captureErrorOnce() throws InterruptedException{
+       count = new AtomicInteger(0);
+        new SimpleReact().of("hello","world")
+                         .capture(e->count.incrementAndGet())
+                         .peek(System.out::println)
+                         .then(this::exception)
+                         .peek(System.out::println)
+                         .then(s->"hello"+s)
+                         .run();
+                         
+        Thread.sleep(500);                 
+        assertEquals(count.get(),2);
+    }
     @Test
     public void captureBlock(){
         t=null;

--- a/src/test/java/com/aol/cyclops/react/simple/CaptureTest.java
+++ b/src/test/java/com/aol/cyclops/react/simple/CaptureTest.java
@@ -1,0 +1,98 @@
+package com.aol.cyclops.react.simple;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.aol.cyclops.control.LazyReact;
+import com.aol.cyclops.control.SimpleReact;
+import com.aol.cyclops.react.SimpleReactFailedStageException;
+
+public class CaptureTest {
+
+    private String exception(String in){
+        throw new InternalException();
+    }
+    @Test
+    public void capture() throws InterruptedException{
+        t=null;
+        new SimpleReact().of("hello","world")
+                         .capture(e->t=e)
+                         .peek(System.out::println)
+                         .then(this::exception)
+                         .peek(System.out::println)
+                         .then(s->"hello"+s);
+                         
+        Thread.sleep(500);                 
+        assertNotNull(t);
+        assertFalse(t.toString(),t instanceof SimpleReactFailedStageException);
+        assertTrue(t.toString(),t instanceof InternalException);
+    }
+    @Test
+    public void captureLast() throws InterruptedException{
+        t=null;
+        new SimpleReact().of("hello","world")
+                         .capture(e->t=e)
+                         .peek(System.out::println)
+                         .peek(System.out::println)
+                         .then(s->"hello"+s)
+                         .then(this::exception);
+        
+                         
+        Thread.sleep(500);                 
+        assertNotNull(t);
+        assertFalse(t.toString(),t instanceof SimpleReactFailedStageException);
+        assertTrue(t.toString(),t instanceof InternalException);
+    }
+    Throwable second = null;
+    @Test
+    public void captureErrorOnce() throws InterruptedException{
+        t=null;
+        second =null;
+        new SimpleReact().of("hello","world")
+                         .capture(e->t=e)
+                         .peek(System.out::println)
+                         .then(this::exception)
+                         .peek(System.out::println)
+                         .capture(e->second=t)
+                         .then(s->"hello"+s);
+                         
+        Thread.sleep(500);                 
+        assertNotNull(t);
+        assertNull(second);
+        assertFalse(t.toString(),t instanceof SimpleReactFailedStageException);
+        assertTrue(t.toString(),t instanceof InternalException);
+    }
+    @Test
+    public void captureBlock(){
+        t=null;
+        new SimpleReact().of("hello","world").capture(e->t=e)
+                         .peek(System.out::println)
+                         .then(this::exception)
+                         .peek(System.out::println)
+                         .block();
+                         
+        assertNotNull(t);
+        t.printStackTrace();
+        assertFalse(t.toString(),t instanceof SimpleReactFailedStageException);
+        assertTrue(t.toString(),t instanceof InternalException);
+    }
+    Throwable t;
+    @Test
+    public void captureLazy(){
+        t=null;
+        new LazyReact().of("hello","world")
+                        .capture(e->t=e)
+                        .peek(System.out::println)
+                        .then(this::exception)
+                        .forEach(System.out::println);
+                         
+        assertNotNull(t);
+        assertFalse(t.toString(),t instanceof SimpleReactFailedStageException);
+        assertTrue(t.toString(),t instanceof InternalException);
+    }
+    
+    private static class InternalException extends RuntimeException{
+        
+    }
+}

--- a/src/test/java/com/aol/cyclops/react/simple/OnFailTest.java
+++ b/src/test/java/com/aol/cyclops/react/simple/OnFailTest.java
@@ -1,10 +1,11 @@
 package com.aol.cyclops.react.simple;
 
-import java.io.IOException;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/com/aol/cyclops/react/simple/RetryTest.java
+++ b/src/test/java/com/aol/cyclops/react/simple/RetryTest.java
@@ -121,7 +121,7 @@ public class RetryTest {
 
 		
 		assertThat(result.size(), is(0));
-		assertThat(((SimpleReactFailedStageException)error).getCause().getMessage(), is("DONT PANIC"));
+		assertThat(error.getMessage(), is("DONT PANIC"));
 
 	}
 
@@ -162,8 +162,8 @@ public class RetryTest {
 		assertThat(result.size(), is(0));
 
 		error.printStackTrace();
-		assertThat(error.getCause(), instanceOf(IllegalArgumentException.class));
-		assertThat(error.getCause().getMessage(), is("DONT PANIC"));
+		assertThat(error, instanceOf(IllegalArgumentException.class));
+		assertThat(error.getMessage(), is("DONT PANIC"));
 	}
 
 	

--- a/src/test/java/com/aol/cyclops/react/stream/pushable/PushableStreamTest.java
+++ b/src/test/java/com/aol/cyclops/react/stream/pushable/PushableStreamTest.java
@@ -17,24 +17,68 @@ import org.jooq.lambda.tuple.Tuple2;
 import org.junit.Test;
 import org.mockito.internal.util.collections.Sets;
 
+import com.aol.cyclops.control.Eval;
 import com.aol.cyclops.control.LazyReact;
+import com.aol.cyclops.control.Maybe;
+import com.aol.cyclops.control.Pipes;
 import com.aol.cyclops.control.ReactiveSeq;
 import com.aol.cyclops.control.StreamSource;
 import com.aol.cyclops.data.async.Queue;
 import com.aol.cyclops.data.async.QueueFactories;
 import com.aol.cyclops.data.async.Signal;
+import com.aol.cyclops.data.collections.extensions.persistent.PSetX;
+import com.aol.cyclops.data.collections.extensions.persistent.PStackX;
+import com.aol.cyclops.data.collections.extensions.standard.ListX;
+import com.aol.cyclops.data.collections.extensions.standard.SetX;
 import com.aol.cyclops.react.threads.SequentialElasticPools;
 import com.aol.cyclops.types.futurestream.LazyFutureStream;
+import com.aol.cyclops.types.stream.reactive.ValueSubscriber;
 import com.aol.cyclops.util.stream.pushable.MultipleStreamSource;
 import com.aol.cyclops.util.stream.pushable.PushableLazyFutureStream;
 import com.aol.cyclops.util.stream.pushable.PushableReactiveSeq;
 import com.aol.cyclops.util.stream.pushable.PushableStream;
 
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
 
 public class PushableStreamTest {
+    
+    @Test
+    public void pipes() throws InterruptedException{
+        
+        Flux.from(PStackX.of(10,20,30));
+        
+        SetX.fromPublisher(Flux.just(10,20,30));
+        
+        PSetX.of(1,2,3)
+             .flatMapPublisher(i->Flux.just(i,i*10))
+             .toPVectorX();
+        
+        /**
+        Pipes<String, Integer> bus = Pipes.of();
+        bus.register("reactor", QueueFactories.<Integer>boundedNonBlockingQueue(1000)
+                                              .build());
+        //bus.publishTo("reactor",Flux.just(10,20,30));
+        bus.publishTo("reactor",ReactiveSeq.of(10,20,30));
+        
+        System.out.println(Thread.currentThread().getId());
+       System.out.println(bus.futureStream("reactor", new LazyReact(50,50))
+            .get()
+           .map(i->"fan-out to handle blocking I/O:" + Thread.currentThread().getId() + ":"+i)
+           .toList());//.forEach(System.out::println);
+        
+        Thread.sleep(1500);
+        **/
+    }
 
 	@Test
 	public void testLazyFutureStream() {
+	    
+	    
+	    
+	   
+	    
 		PushableLazyFutureStream<Integer> pushable = StreamSource.ofUnbounded()
 				                                                 .futureStream(new LazyReact());
 		pushable.getInput().add(100);


### PR DESCRIPTION

Fix for https://github.com/aol/cyclops-react/issues/174
Fix for https://github.com/aol/cyclops-react/issues/173

This implementation adds a run() method that allows errros to be captured on SimpleReactStreams without using the blocking block() method.