### PR TITLE
Issue #194 fixed - https://github.com/aol/cyclops-react/issues/194.

### DIFF
--- a/src/main/java/com/aol/cyclops/types/extensability/ValueComprehender.java
+++ b/src/main/java/com/aol/cyclops/types/extensability/ValueComprehender.java
@@ -4,7 +4,7 @@ import java.util.Iterator;
 
 public interface ValueComprehender<T> extends Comprehender<T> {
     default T fromIterator(Iterator it){
-        if(it.hasNext())
+        if(!it.hasNext())
             return empty();
         return of(it.next());
     }

--- a/src/test/java/com/aol/cyclops/internal/comprehensions/comprehenders/CompletableFutureComprehenderTest.java
+++ b/src/test/java/com/aol/cyclops/internal/comprehensions/comprehenders/CompletableFutureComprehenderTest.java
@@ -1,0 +1,34 @@
+package com.aol.cyclops.internal.comprehensions.comprehenders;
+
+import org.junit.Test;
+import org.testng.Assert;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Created by weiliyang on 5/24/16.
+ */
+public class CompletableFutureComprehenderTest {
+
+    @Test
+    public void testFromIterator() throws ExecutionException, InterruptedException {
+        CompletableFutureComprehender completableFutureComprehender = new CompletableFutureComprehender();
+        List<String> strs = Arrays.asList("a", "b", "c");
+        CompletableFuture completableFuture = completableFutureComprehender.fromIterator(strs.iterator());
+        Object o = completableFuture.get();
+        Assert.assertEquals(o, "a");
+    }
+    
+    @Test
+    public void testFromIteratorWithEmptyIterator() throws ExecutionException, InterruptedException {
+        CompletableFutureComprehender completableFutureComprehender = new CompletableFutureComprehender();
+        List<String> strs = new ArrayList();
+        CompletableFuture completableFuture = completableFutureComprehender.fromIterator(strs.iterator());
+        Object o = completableFuture.get();
+        Assert.assertNull(o);
+    }
+}


### PR DESCRIPTION
If the iterator has no element then empty (which actually means null) will be returned. Otherwise, first element will be returned.