### PR TITLE
Added test cases to cover mixed usages of different Predicates.

### DIFF
--- a/src/test/java/com/aol/cyclops/control/ReactiveSeqTest.java
+++ b/src/test/java/com/aol/cyclops/control/ReactiveSeqTest.java
@@ -1,0 +1,47 @@
+package com.aol.cyclops.control;
+
+import static com.aol.cyclops.util.function.Predicates.*;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+import org.junit.Test;
+
+import com.aol.cyclops.util.function.Predicates;
+
+public class ReactiveSeqTest {
+
+	@Test
+	public void test1() {
+		ReactiveSeq.of(1, 2, 3).filter(anyOf(not(in(2, 3, 4)), in(1, 10, 20)));
+	}
+
+	@Test
+	public void test2() {
+		ReactiveSeq.of(1, 2, 3).filter(anyOf(not(in(2, 3, 4)), greaterThan(10)));
+	}
+
+	@Test
+	public void test3() {
+		ReactiveSeq.of(Arrays.asList(1, 2, 3), Arrays.asList(2, 3, 4), Arrays.asList(3, 4, 5)).filter(hasItems(Arrays.asList(2, 3)));
+	}
+	
+	@Test
+	public void test4() {
+		ReactiveSeq.of(Arrays.asList(1, 2, 3), Arrays.asList(2, 3, 4), Arrays.asList(3, 4, 5)).filter(not(hasItems(Arrays.asList(2, 3))));
+	}
+	
+	@Test
+	public void test() {
+		/*ReactiveSeq.of(1, 2, 3).filter(noneOf(not(in(2.5, 3, 4)), greaterThan(10.0)));
+		ReactiveSeq.of(1, 2, 3).filter(anyOf(not(in(2.5, 3, 4)), in(10,20,30)));
+		ReactiveSeq.of(1,2,3).filter(anyOf(not(in(2.5,3.5,4.5)),in(1.0,10,20)));
+		ReactiveSeq.of(1, 2, 3).filter(xOf(1, not(in(2.5, 3, 4)), greaterThan(10.0)));*/
+		
+		Predicate<? super Integer> inOne = in(2.4,3,4);
+		Predicate<? super Integer> inTwo = in(1,10,20);
+		ReactiveSeq.of(1,2,3).filter(anyOf(not(inOne),inTwo));
+		ReactiveSeq.of(1,2,3).filter(anyOf(not(in(2.4,3,4)),in(1,10,20)));
+	}
+	
+}


### PR DESCRIPTION
Some test cases to cover mixed usages of different Predicates.

If we remove all the super type usages in Predicates, it will fail compilation in classes for example Matchable and related test cases. We do need the super type.

Currently the following can't be compiled successfully.
ReactiveSeq.of(1, 2, 3).filter(noneOf(not(in(2.5, 3, 4)), greaterThan(10)));

To make it work, it has to be coded as follows:
Predicate<? super Integer> greaterThan = greaterThan(10);
Predicate<? super Integer> _in = in(2.5, 3, 4);
ReactiveSeq.of(1, 2, 3).filter(xOf(1, not(_in), greaterThan));

Is it the case we need to support as well? Thanks.