### PR TITLE
Applied skeletal implementation to interface migration automated refactoring

### DIFF
--- a/src/main/java/com/aol/cyclops/internal/stream/BaseHotStreamImpl.java
+++ b/src/main/java/com/aol/cyclops/internal/stream/BaseHotStreamImpl.java
@@ -5,11 +5,8 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-
-import org.agrona.concurrent.OneToOneConcurrentArrayQueue;
 
 import com.aol.cyclops.control.ReactiveSeq;
 import com.aol.cyclops.internal.stream.spliterators.ClosingSpliterator;
@@ -54,22 +51,12 @@ public abstract class BaseHotStreamImpl<T> extends IteratorHotStream<T> implemen
 	}
 	
 	@Override
-	public ReactiveSeq<T> connect(){
-		return connect(new OneToOneConcurrentArrayQueue<T>(256));
-	}
-	
-	@Override
 	public ReactiveSeq<T> connect(Queue<T> queue) {
 		connections.getAndSet(connected, queue);
 		connected++;
 		unpause();
 		return StreamUtils.reactiveSeq(StreamSupport.stream(
                 new ClosingSpliterator(Long.MAX_VALUE, queue,open), false),Optional.empty());
-	}
-
-	@Override
-	public <R extends Stream<T>> R connectTo(Queue<T> queue,Function<ReactiveSeq<T>,R> to) {
-		return to.apply(connect(queue));
 	}
 	
 }

--- a/src/main/java/com/aol/cyclops/types/stream/HotStream.java
+++ b/src/main/java/com/aol/cyclops/types/stream/HotStream.java
@@ -4,10 +4,16 @@ import java.util.Queue;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import org.agrona.concurrent.OneToOneConcurrentArrayQueue;
+
 import com.aol.cyclops.control.ReactiveSeq;
 
 public interface HotStream<T> {
-	public ReactiveSeq<T> connect();
+	public default ReactiveSeq<T> connect() {
+		return connect(new OneToOneConcurrentArrayQueue<T>(256));
+	}
 	public ReactiveSeq<T> connect(Queue<T> queue);
-	public <R extends Stream<T>> R connectTo(Queue<T> queue,Function<ReactiveSeq<T>,R> to);
+	public default <R extends Stream<T>> R connectTo(Queue<T> queue,Function<ReactiveSeq<T>,R> to) {
+		return to.apply(connect(queue));
+	}
 }


### PR DESCRIPTION
This is a semantics-preserving automated refactoring that migrates existing method implementations in classes to the corresponding implemented interface methods as `default` methods. The tool **does not** add new code; it only rearranges *existing* code.

- We are evaluating a research prototype automated refactoring Eclipse plug-in called [Migrate Skeletal Implementation to Interface](https://github.com/khatchad/Migrate-Skeletal-Implementation-to-Interface-Refactoring). We have applied the tool to your project in the hopes of receiving feedback.
- The approach is very conservative. That may mean that not all changes that can be made were made. Please feel free to continue the refactoring manually if you wish.
- We only migrated methods declared in abstract classes with the hopes of such methods being suitable default methods in corresponding interfaces.
- The source code should be semantically equivalent to the original.

Thank you for your help in this evaluation! Any feedback you can provide would be very helpful. In particular, we are interested if *each* of the proposed changes are helpful or not.