### PR TITLE
Rename ApplicativeFunctor#ap to combine

### DIFF
--- a/src/main/java/com/aol/cyclops/control/Eval.java
+++ b/src/main/java/com/aol/cyclops/control/Eval.java
@@ -219,9 +219,9 @@ public interface Eval<T> extends Supplier<T>,
      * @return
      */
     @Override
-    default <T2,R> Eval<R> ap(Value<? extends T2> app, BiFunction<? super T,? super T2,? extends R> fn){
+    default <T2,R> Eval<R> combine(Value<? extends T2> app, BiFunction<? super T,? super T2,? extends R> fn){
         
-        return  (Eval<R> )ApplicativeFunctor.super.ap(app, fn);
+        return  (Eval<R> )ApplicativeFunctor.super.combine(app, fn);
     }
     /**
      * Equivalent to ap, but accepts an Iterable and takes the first value only from that iterable.

--- a/src/main/java/com/aol/cyclops/control/FeatureToggle.java
+++ b/src/main/java/com/aol/cyclops/control/FeatureToggle.java
@@ -514,7 +514,7 @@ public interface FeatureToggle<F> extends Supplier<F>,
 		     * @return
 		     */
 		    @Override
-		    default <T2,R> FeatureToggle<R> ap(Value<? extends T2> app, BiFunction<? super F,? super T2,? extends R> fn){
+		    default <T2,R> FeatureToggle<R> combine(Value<? extends T2> app, BiFunction<? super F,? super T2,? extends R> fn){
 		        
 		        return map(v->Tuple.tuple(v,Curry.curry2(fn).apply(v)))
 		                  .flatMap(tuple-> app.visit(i->Maybe.just(tuple.v2.apply(i)),()->Maybe.none() ));

--- a/src/main/java/com/aol/cyclops/control/FutureW.java
+++ b/src/main/java/com/aol/cyclops/control/FutureW.java
@@ -366,7 +366,7 @@ public class FutureW<T> implements ConvertableFunctor<T>,
      * @return
      */
     @Override
-    public <T2,R> FutureW<R> ap(Value<? extends T2> app, BiFunction<? super T,? super T2,? extends R> fn){
+    public <T2,R> FutureW<R> combine(Value<? extends T2> app, BiFunction<? super T,? super T2,? extends R> fn){
         if(app instanceof FutureW){
             return FutureW.of(future.thenCombine( ((FutureW<T2>)app).getFuture(),fn));
         }

--- a/src/main/java/com/aol/cyclops/control/Ior.java
+++ b/src/main/java/com/aol/cyclops/control/Ior.java
@@ -162,7 +162,7 @@ public interface Ior<ST,PT> extends Supplier<PT>,
         
         return Matchables.tuple2(both().get()).visit((a,b)-> both.apply(a, b));
     }
-	default <R1,R2> Ior<R1,R2> visitIor(Function<? super ST,? extends R1> secondary, 
+	default <R1,R2> Ior<R1,R2> mapBoth(Function<? super ST,? extends R1> secondary, 
 			Function<? super PT,? extends R2> primary){
 		if(isSecondary())
 			return (Ior<R1,R2>)swap().map(secondary).swap();

--- a/src/main/java/com/aol/cyclops/control/Ior.java
+++ b/src/main/java/com/aol/cyclops/control/Ior.java
@@ -441,7 +441,7 @@ public interface Ior<ST,PT> extends Supplier<PT>,
          * @see com.aol.cyclops.types.applicative.ApplicativeFunctor#ap(com.aol.cyclops.types.Value, java.util.function.BiFunction)
          */
         @Override
-        public <T2, R> Ior<ST,R> ap(Value<? extends T2> app, BiFunction<? super PT, ? super T2, ? extends R> fn) {
+        public <T2, R> Ior<ST,R> combine(Value<? extends T2> app, BiFunction<? super PT, ? super T2, ? extends R> fn) {
            
             return  app.toXor().visit(s->Ior.secondary(null), f->Ior.primary(fn.apply(get(),app.get())));
         }
@@ -593,7 +593,7 @@ public interface Ior<ST,PT> extends Supplier<PT>,
          * @see com.aol.cyclops.types.applicative.ApplicativeFunctor#ap(com.aol.cyclops.types.Value, java.util.function.BiFunction)
          */
         @Override
-        public <T2, R> Ior<ST,R> ap(Value<? extends T2> app, BiFunction<? super PT, ? super T2, ? extends R> fn) {
+        public <T2, R> Ior<ST,R> combine(Value<? extends T2> app, BiFunction<? super PT, ? super T2, ? extends R> fn) {
             return (Ior<ST,R>)this;
         }
 	}
@@ -738,7 +738,7 @@ public interface Ior<ST,PT> extends Supplier<PT>,
          * @see com.aol.cyclops.types.applicative.ApplicativeFunctor#ap(com.aol.cyclops.types.Value, java.util.function.BiFunction)
          */
         @Override
-        public <T2, R> Ior<ST,R> ap(Value<? extends T2> app, BiFunction<? super PT, ? super T2, ? extends R> fn) {
+        public <T2, R> Ior<ST,R> combine(Value<? extends T2> app, BiFunction<? super PT, ? super T2, ? extends R> fn) {
             return  app.toXor().visit(s->Ior.secondary(this.secondaryGet()), f->Ior.both(this.secondaryGet(),fn.apply(get(),app.get())));
         }
 	}

--- a/src/main/java/com/aol/cyclops/control/Maybe.java
+++ b/src/main/java/com/aol/cyclops/control/Maybe.java
@@ -156,7 +156,7 @@ public interface Maybe<T> extends MonadicValue1<T>,
 	 * @return
 	 */
 	@Override
-	default <T2,R> Maybe<R> ap(Value<? extends T2> app, BiFunction<? super T,? super T2,? extends R> fn){
+	default <T2,R> Maybe<R> combine(Value<? extends T2> app, BiFunction<? super T,? super T2,? extends R> fn){
         
         return map(v->Tuple.tuple(v,Curry.curry2(fn).apply(v)))
                   .flatMap(tuple-> app.visit(i->Maybe.just(tuple.v2.apply(i)),()->Maybe.none() ));

--- a/src/main/java/com/aol/cyclops/control/Try.java
+++ b/src/main/java/com/aol/cyclops/control/Try.java
@@ -952,7 +952,7 @@ public interface Try<T,X extends Throwable> extends Supplier<T>,
 
 		 
 	    @Override
-	    public <T2,R> Try<R,X> ap(Value<? extends T2> app, BiFunction<? super T,? super T2,? extends R> fn){
+	    public <T2,R> Try<R,X> combine(Value<? extends T2> app, BiFunction<? super T,? super T2,? extends R> fn){
 	     return  app.toTry().visit(s->safeApply( ()->success(fn.apply(get(),app.get()))), f->Try.failure(null));
 	     
 	    }
@@ -1258,7 +1258,7 @@ public interface Try<T,X extends Throwable> extends Supplier<T>,
 		}
 
         @Override
-        public <T2, R> Try<R, X> ap(Value<? extends T2> app, BiFunction<? super T, ? super T2, ? extends R> fn) {
+        public <T2, R> Try<R, X> combine(Value<? extends T2> app, BiFunction<? super T, ? super T2, ? extends R> fn) {
             return (Try<R, X>)this;
 
         }
@@ -1296,8 +1296,8 @@ public interface Try<T,X extends Throwable> extends Supplier<T>,
      * @see com.aol.cyclops.types.applicative.ApplicativeFunctor#ap(com.aol.cyclops.types.Value, java.util.function.BiFunction)
      */
     @Override
-    default <T2, R> Try<R, X> ap(Value<? extends T2> app, BiFunction<? super T, ? super T2, ? extends R> fn) {
-        return (Try<R, X>)ApplicativeFunctor.super.ap(app, fn);
+    default <T2, R> Try<R, X> combine(Value<? extends T2> app, BiFunction<? super T, ? super T2, ? extends R> fn) {
+        return (Try<R, X>)ApplicativeFunctor.super.combine(app, fn);
     }
     /**
      * Equivalent to ap, but accepts an Iterable and takes the first value

--- a/src/main/java/com/aol/cyclops/control/Xor.java
+++ b/src/main/java/com/aol/cyclops/control/Xor.java
@@ -220,7 +220,7 @@ public interface Xor<ST,PT> extends Supplier<PT>,
 	<R> R visit(Function<? super ST,? extends R> secondary, 
             Function<? super PT,? extends R> primary);
 	
-	default <R1,R2> Xor<R1,R2> visitXor(Function<? super ST,? extends R1> secondary, 
+	default <R1,R2> Xor<R1,R2> mapBoth(Function<? super ST,? extends R1> secondary, 
 			Function<? super PT,? extends R2> primary){
 		if(isSecondary())
 			return (Xor<R1,R2>)swap().map(secondary).swap();

--- a/src/main/java/com/aol/cyclops/control/Xor.java
+++ b/src/main/java/com/aol/cyclops/control/Xor.java
@@ -259,10 +259,10 @@ public interface Xor<ST,PT> extends Supplier<PT>,
      * @see com.aol.cyclops.types.applicative.ApplicativeFunctor#ap(com.aol.cyclops.types.Value, java.util.function.BiFunction)
      */
     @Override
-    <T2, R> Xor<ST,R> ap(Value<? extends T2> app, BiFunction<? super PT, ? super T2, ? extends R> fn);
+    <T2, R> Xor<ST,R> combine(Value<? extends T2> app, BiFunction<? super PT, ? super T2, ? extends R> fn);
     
     /**
-     * @return An Xor with the secondary type converted to a persistent list, for use with accumulating app function  {@link Xor#ap(Xor,BiFunction)}
+     * @return An Xor with the secondary type converted to a persistent list, for use with accumulating app function  {@link Xor#combine(Xor,BiFunction)}
      */
     default Xor<PStackX<ST>,PT> list(){
         return secondaryMap(PStackX::of);
@@ -277,8 +277,8 @@ public interface Xor<ST,PT> extends Supplier<PT>,
      * @param fn Combiner function for primary values
      * @return Combined Xor
      */
-    default <T2, R> Xor<PStackX<ST>,R> apToList(Xor<ST,? extends T2> app,BiFunction<? super PT, ? super T2, ? extends R> fn){
-      return list().ap(app.list(),Semigroups.collectionXConcat(),fn);
+    default <T2, R> Xor<PStackX<ST>,R> combineToList(Xor<ST,? extends T2> app,BiFunction<? super PT, ? super T2, ? extends R> fn){
+      return list().combine(app.list(),Semigroups.collectionXConcat(),fn);
     }
     /**
      * Accumulate secondary values with the provided BinaryOperator / Semigroup {@link Semigroups}
@@ -298,7 +298,8 @@ public interface Xor<ST,PT> extends Supplier<PT>,
      * @param fn To combine primary types
      * @return Combined Xor
      */
-    default <T2, R> Xor<ST,R> ap(Xor<? extends ST,? extends T2> app, BinaryOperator<ST> semigroup,BiFunction<? super PT, ? super T2, ? extends R> fn){
+   
+    default <T2, R> Xor<ST,R> combine(Xor<? extends ST,? extends T2> app, BinaryOperator<ST> semigroup,BiFunction<? super PT, ? super T2, ? extends R> fn){
         return this.visit(secondary-> app.visit(s2->Xor.secondary( semigroup.apply(s2, secondary)), p2->Xor.secondary(secondary))
                     , primary->   app.visit(s2->Xor.secondary(s2), p2->Xor.primary(fn.apply(primary,p2))));
       }
@@ -492,7 +493,7 @@ public interface Xor<ST,PT> extends Supplier<PT>,
          * @see com.aol.cyclops.types.applicative.ApplicativeFunctor#ap(com.aol.cyclops.types.Value, java.util.function.BiFunction)
          */
         @Override
-        public <T2, R> Xor<ST,R> ap(Value<? extends T2> app, BiFunction<? super PT, ? super T2, ? extends R> fn) {
+        public <T2, R> Xor<ST,R> combine(Value<? extends T2> app, BiFunction<? super PT, ? super T2, ? extends R> fn) {
             return  app.toXor().visit(s->Xor.secondary(null), f->Xor.primary(fn.apply(get(),app.get())));
         }
 
@@ -617,7 +618,7 @@ public interface Xor<ST,PT> extends Supplier<PT>,
          * @see com.aol.cyclops.types.applicative.ApplicativeFunctor#ap(com.aol.cyclops.types.Value, java.util.function.BiFunction)
          */
         @Override
-        public <T2, R> Xor<ST,R> ap(Value<? extends T2> app, BiFunction<? super PT, ? super T2, ? extends R> fn) {
+        public <T2, R> Xor<ST,R> combine(Value<? extends T2> app, BiFunction<? super PT, ? super T2, ? extends R> fn) {
            return (Xor<ST,R>)this;
         }
 

--- a/src/main/java/com/aol/cyclops/control/monads/transformers/values/CompletableFutureTValue.java
+++ b/src/main/java/com/aol/cyclops/control/monads/transformers/values/CompletableFutureTValue.java
@@ -136,9 +136,9 @@ public class CompletableFutureTValue<A> implements CompletableFutureT<A>,
      * types.Value, java.util.function.BiFunction)
      */
     @Override
-    public <T2, R> CompletableFutureTValue<R> ap(Value<? extends T2> app,
+    public <T2, R> CompletableFutureTValue<R> combine(Value<? extends T2> app,
             BiFunction<? super A, ? super T2, ? extends R> fn) {
-        return new CompletableFutureTValue<R>(run.map(o-> CompletableFutures.ap(o, app, fn)));
+        return new CompletableFutureTValue<R>(run.map(o-> CompletableFutures.combine(o, app, fn)));
     }
 
     /*

--- a/src/main/java/com/aol/cyclops/control/monads/transformers/values/EvalTValue.java
+++ b/src/main/java/com/aol/cyclops/control/monads/transformers/values/EvalTValue.java
@@ -139,8 +139,8 @@ public class EvalTValue<T> implements EvalT<T>,
      * @see com.aol.cyclops.types.applicative.ApplicativeFunctor#ap(com.aol.cyclops.types.Value, java.util.function.BiFunction)
      */
     @Override
-    public <T2, R> EvalTValue<R> ap(Value<? extends T2> app, BiFunction<? super T, ? super T2, ? extends R> fn) {
-        return new EvalTValue<R>(run.map(o -> o.ap(app,fn)));
+    public <T2, R> EvalTValue<R> combine(Value<? extends T2> app, BiFunction<? super T, ? super T2, ? extends R> fn) {
+        return new EvalTValue<R>(run.map(o -> o.combine(app,fn)));
         
     }
     /* (non-Javadoc)

--- a/src/main/java/com/aol/cyclops/control/monads/transformers/values/FutureWTValue.java
+++ b/src/main/java/com/aol/cyclops/control/monads/transformers/values/FutureWTValue.java
@@ -133,9 +133,9 @@ public class FutureWTValue<A> implements FutureWT<A>,
      * types.Value, java.util.function.BiFunction)
      */
     @Override
-    public <T2, R> FutureWTValue<R> ap(Value<? extends T2> app,
+    public <T2, R> FutureWTValue<R> combine(Value<? extends T2> app,
             BiFunction<? super A, ? super T2, ? extends R> fn) {
-        return new FutureWTValue<>(run.map(o-> o.ap(app,fn)));
+        return new FutureWTValue<>(run.map(o-> o.combine(app,fn)));
     }
 
     /*

--- a/src/main/java/com/aol/cyclops/control/monads/transformers/values/MaybeTValue.java
+++ b/src/main/java/com/aol/cyclops/control/monads/transformers/values/MaybeTValue.java
@@ -141,9 +141,9 @@ public class MaybeTValue<T> implements MaybeT<T>,
      * @see com.aol.cyclops.types.applicative.ApplicativeFunctor#ap(com.aol.cyclops.types.Value, java.util.function.BiFunction)
      */
     @Override
-    public <T2, R> MaybeTValue<R> ap(Value<? extends T2> app,
+    public <T2, R> MaybeTValue<R> combine(Value<? extends T2> app,
             BiFunction<? super T, ? super T2, ? extends R> fn) {
-        return new MaybeTValue<>(run.map(o -> o.ap(app,fn)));
+        return new MaybeTValue<>(run.map(o -> o.combine(app,fn)));
     }
 
     /* (non-Javadoc)

--- a/src/main/java/com/aol/cyclops/control/monads/transformers/values/OptionalTValue.java
+++ b/src/main/java/com/aol/cyclops/control/monads/transformers/values/OptionalTValue.java
@@ -137,9 +137,9 @@ public class OptionalTValue<T> implements OptionalT<T>,
      * @see com.aol.cyclops.types.applicative.ApplicativeFunctor#ap(com.aol.cyclops.types.Value, java.util.function.BiFunction)
      */
     @Override
-    public <T2, R> OptionalTValue<R> ap(Value<? extends T2> app,
+    public <T2, R> OptionalTValue<R> combine(Value<? extends T2> app,
             BiFunction<? super T, ? super T2, ? extends R> fn) {
-        return new OptionalTValue<>(run.map(o -> Optionals.ap(o,app,fn)));
+        return new OptionalTValue<>(run.map(o -> Optionals.combine(o,app,fn)));
     }
     /* (non-Javadoc)
      * @see com.aol.cyclops.types.applicative.ApplicativeFunctor#zip(java.lang.Iterable, java.util.function.BiFunction)

--- a/src/main/java/com/aol/cyclops/control/monads/transformers/values/TryTValue.java
+++ b/src/main/java/com/aol/cyclops/control/monads/transformers/values/TryTValue.java
@@ -135,9 +135,9 @@ public class TryTValue<T,X extends Throwable> implements TryT<T,X>,
      * @see com.aol.cyclops.types.applicative.ApplicativeFunctor#ap(com.aol.cyclops.types.Value, java.util.function.BiFunction)
      */
     @Override
-    public <T2, R> TryTValue<R,X> ap(Value<? extends T2> app,
+    public <T2, R> TryTValue<R,X> combine(Value<? extends T2> app,
             BiFunction<? super T, ? super T2, ? extends R> fn) {
-        return new TryTValue<>(run.map(o -> o.ap(app,fn)));
+        return new TryTValue<>(run.map(o -> o.combine(app,fn)));
     }
     /* (non-Javadoc)
      * @see com.aol.cyclops.types.applicative.ApplicativeFunctor#zip(java.lang.Iterable, java.util.function.BiFunction)

--- a/src/main/java/com/aol/cyclops/control/monads/transformers/values/XorTValue.java
+++ b/src/main/java/com/aol/cyclops/control/monads/transformers/values/XorTValue.java
@@ -12,14 +12,11 @@ import java.util.function.Supplier;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
-import com.aol.cyclops.Semigroup;
-import com.aol.cyclops.Semigroups;
 import com.aol.cyclops.control.AnyM;
 import com.aol.cyclops.control.Matchable;
 import com.aol.cyclops.control.Matchable.CheckValue1;
 import com.aol.cyclops.control.ReactiveSeq;
 import com.aol.cyclops.control.Trampoline;
-import com.aol.cyclops.control.Try;
 import com.aol.cyclops.control.Xor;
 import com.aol.cyclops.control.monads.transformers.XorT;
 import com.aol.cyclops.data.collections.extensions.persistent.PStackX;
@@ -153,9 +150,9 @@ public class XorTValue<ST,T> implements XorT<ST,T>,
      * @see com.aol.cyclops.types.applicative.ApplicativeFunctor#ap(com.aol.cyclops.types.Value, java.util.function.BiFunction)
      */
     @Override
-    public <T2, R> XorTValue<ST,R> ap(Value<? extends T2> app,
+    public <T2, R> XorTValue<ST,R> combine(Value<? extends T2> app,
             BiFunction<? super T, ? super T2, ? extends R> fn) {
-        return new XorTValue<>(run.map(o -> o.ap(app,fn)));
+        return new XorTValue<>(run.map(o -> o.combine(app,fn)));
     }
     /* (non-Javadoc)
      * @see com.aol.cyclops.types.applicative.ApplicativeFunctor#zip(java.lang.Iterable, java.util.function.BiFunction)
@@ -178,11 +175,12 @@ public class XorTValue<ST,T> implements XorT<ST,T>,
     }
     
  
-    public <T2, R> XorTValue<PStackX<ST>,R> apToList(Xor<ST,? extends T2> app,BiFunction<? super T, ? super T2, ? extends R> fn){
-        return new XorTValue<>(run.map(o -> o.apToList(app,fn)));
+    public <T2, R> XorTValue<PStackX<ST>,R> combineToList(Xor<ST,? extends T2> app,BiFunction<? super T, ? super T2, ? extends R> fn){
+        return new XorTValue<>(run.map(o -> o.combineToList(app,fn)));
     }
-   public <T2, R> XorTValue<ST,R> ap(Xor<? extends ST,? extends T2> app, BinaryOperator<ST> semigroup,BiFunction<? super T, ? super T2, ? extends R> fn){
-       return new XorTValue<>(run.map(o -> o.ap(app,semigroup,fn)));
+    
+   public <T2, R> XorTValue<ST,R> combine(Xor<? extends ST,? extends T2> app, BinaryOperator<ST> semigroup,BiFunction<? super T, ? super T2, ? extends R> fn){
+       return new XorTValue<>(run.map(o -> o.combine(app,semigroup,fn)));
       }
     /**
      * Flat Map the wrapped Xor

--- a/src/main/java/com/aol/cyclops/internal/monads/AnyMValueImpl.java
+++ b/src/main/java/com/aol/cyclops/internal/monads/AnyMValueImpl.java
@@ -45,11 +45,11 @@ public class AnyMValueImpl<T> extends BaseAnyMImpl<T> implements AnyMValue<T> {
      * @see com.aol.cyclops.types.anyM.AnyMValue#ap(com.aol.cyclops.types.Value, java.util.function.BiFunction)
      */
     @Override
-    public <T2, R> AnyMValue<R> ap(Value<? extends T2> app, BiFunction<? super T, ? super T2, ? extends R> fn) {
+    public <T2, R> AnyMValue<R> combine(Value<? extends T2> app, BiFunction<? super T, ? super T2, ? extends R> fn) {
         if(this.unwrap() instanceof ApplicativeFunctor){
-            return AnyM.<R>ofValue(((ApplicativeFunctor)unwrap()).ap(app, fn));
+            return AnyM.<R>ofValue(((ApplicativeFunctor)unwrap()).combine(app, fn));
         }
-        return with((AnyM)AnyMValue.super.ap(app, fn));
+        return with((AnyM)AnyMValue.super.combine(app, fn));
     }
     @Override
     public <T2, R> AnyMValue<R> zip(Iterable<? extends T2> app,

--- a/src/main/java/com/aol/cyclops/types/Convertable.java
+++ b/src/main/java/com/aol/cyclops/types/Convertable.java
@@ -10,18 +10,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
-import java.util.function.BiPredicate;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
 
-import com.aol.cyclops.control.Eval;
 import com.aol.cyclops.control.FutureW;
-import com.aol.cyclops.control.Matchable;
-import com.aol.cyclops.control.Maybe;
-import com.aol.cyclops.control.Matchable.CheckValue1;
 
 import lombok.Value;
 

--- a/src/main/java/com/aol/cyclops/types/anyM/AnyMValue.java
+++ b/src/main/java/com/aol/cyclops/types/anyM/AnyMValue.java
@@ -60,9 +60,9 @@ public interface AnyMValue<T> extends AnyM<T>,
      * @see com.aol.cyclops.types.applicative.ApplicativeFunctor#ap(com.aol.cyclops.types.Value, java.util.function.BiFunction)
      */
     @Override
-    default <T2, R> AnyMValue<R> ap(Value<? extends T2> app,
+    default <T2, R> AnyMValue<R> combine(Value<? extends T2> app,
             BiFunction<? super T, ? super T2, ? extends R> fn){
-        return (AnyMValue<R>)ApplicativeFunctor.super.ap(app, fn);
+        return (AnyMValue<R>)ApplicativeFunctor.super.combine(app, fn);
     }
     /* (non-Javadoc)
      * @see com.aol.cyclops.types.applicative.ApplicativeFunctor#zip(java.lang.Iterable, java.util.function.BiFunction)

--- a/src/main/java/com/aol/cyclops/types/applicative/Applicative2.java
+++ b/src/main/java/com/aol/cyclops/types/applicative/Applicative2.java
@@ -29,18 +29,18 @@ public interface Applicative2<T,T2,R, D extends ConvertableFunctor<R>> extends F
 	//<U extends Functor<Function<? super T,? extends R>> & Convertable<Function<? super T,? extends R>>> U delegate();
 	ConvertableFunctor<Function<? super T,Function<? super T2,? extends R>>>  delegate();
 	
-	default Applicative<T2,R,D> ap(Functor<T> f){
+	default EagerApplicative<T2,R,D> ap(Functor<T> f){
 	    
 		return ()->(ConvertableFunctor)delegate().visit(myFn->f.map(t->myFn.apply(t)),()->Maybe.none());
 		
 	}
-	default Applicative<T2,R,D> ap(Optional<T> f){
+	default EagerApplicative<T2,R,D> ap(Optional<T> f){
 		
 		return ap(Maybe.fromOptional(f));
 		
 		
 	}
-	default Applicative<T2,R,D> ap(CompletableFuture<T> f){
+	default EagerApplicative<T2,R,D> ap(CompletableFuture<T> f){
 		return ap(FutureW.of(f));
 		
 	}

--- a/src/main/java/com/aol/cyclops/types/applicative/ApplicativeFunctor.java
+++ b/src/main/java/com/aol/cyclops/types/applicative/ApplicativeFunctor.java
@@ -44,7 +44,14 @@ public interface ApplicativeFunctor<T> extends ConvertableFunctor<T>,
 	}
 	
 	    
-	default <T2,R> ApplicativeFunctor<R> ap(Value<? extends T2> app, BiFunction<? super T,? super T2,? extends R> fn){
+	/**
+	 * Lazily combine this ApplicativeFunctor with the supplied value via the supplied BiFunction
+	 * 
+	 * @param app Value to combine with this one.
+	 * @param fn BiFunction to combine them
+	 * @return New Applicativefunctor that represents the combined values
+	 */
+	default <T2,R> ApplicativeFunctor<R> combine(Value<? extends T2> app, BiFunction<? super T,? super T2,? extends R> fn){
 	       
 	        return (ApplicativeFunctor<R>)map(v->Tuple.tuple(v,Curry.curry2(fn).apply(v)))
 	                                  .map(tuple-> app.visit(i->tuple.v2.apply(i),()->tuple.v1 ));
@@ -60,6 +67,11 @@ public interface ApplicativeFunctor<T> extends ConvertableFunctor<T>,
                                       .map(tuple-> Maybe.fromPublisher(app).visit(i->tuple.v2.apply(i),()->tuple.v1 ));
    } 
 	    
+	    /**
+	     * Eagerly apply functions across one or more Functor instances
+	     * 
+	     * @return ApplyFunctions builder
+	     */
 	    default ApplyFunctions<T> applyFunctions(){
 	        return new ApplyFunctions<T>(this);
 	    }
@@ -141,7 +153,7 @@ public interface ApplicativeFunctor<T> extends ConvertableFunctor<T>,
         	 * @param fn
         	 * @return
         	 */
-        	public <T2,R> Applicative<T2,R, ?> ap2( BiFunction<? super T,? super T2,? extends R> fn){
+        	public <T2,R> EagerApplicative<T2,R, ?> ap2( BiFunction<? super T,? super T2,? extends R> fn){
         		return  Applicatives.<T,R>applicatives(app,app).applicative2(fn);
         	}
         	public <T2,T3,R> Applicative2<T2,T3,R, ?> ap3( TriFunction<? super T,? super T2,? super T3,? extends R> fn){

--- a/src/main/java/com/aol/cyclops/types/applicative/ApplyingApplicativeBuilder.java
+++ b/src/main/java/com/aol/cyclops/types/applicative/ApplyingApplicativeBuilder.java
@@ -21,24 +21,24 @@ public class ApplyingApplicativeBuilder<T,R, A extends ApplicativeFunctor<R> >  
 		private ApplicativeFunctor unit(Function fn){
 			return (ApplicativeFunctor)unit.unit(fn);
 		}
-		public Applicative<T,R,A> applicative(ApplicativeFunctor<Function<? super T,? extends R>> fn){
+		public EagerApplicative<T,R,A> applicative(ApplicativeFunctor<Function<? super T,? extends R>> fn){
 			
 			return ()->fn;
 		}
-		public  Applicative<T,R,A> applicative(Function<? super T,? extends R> fn){
+		public  EagerApplicative<T,R,A> applicative(Function<? super T,? extends R> fn){
 			
 			return applicative(unit(fn));
 		}
-		public <T2> Applicative<T2,R,A> applicative2(ApplicativeFunctor<Function<? super T,Function<? super T2,? extends R>>> fn){
+		public <T2> EagerApplicative<T2,R,A> applicative2(ApplicativeFunctor<Function<? super T,Function<? super T2,? extends R>>> fn){
 			Applicative2<T,T2,R,A> app = ()->fn;
 			return app.ap(functor);
 			
 		}
-		public <T2> Applicative<T2,R,A> applicative2(Function<? super T,Function<? super T2,? extends R>> fn){
+		public <T2> EagerApplicative<T2,R,A> applicative2(Function<? super T,Function<? super T2,? extends R>> fn){
 			
 			return applicative2(unit(fn));
 		}
-		public <T2> Applicative<T2,R,A> applicative2(BiFunction<? super T,? super T2,? extends R> fn){
+		public <T2> EagerApplicative<T2,R,A> applicative2(BiFunction<? super T,? super T2,? extends R> fn){
 			
 			return applicative2(unit(CurryVariance.curry2(fn)));
 		}

--- a/src/main/java/com/aol/cyclops/types/applicative/EagerApplicative.java
+++ b/src/main/java/com/aol/cyclops/types/applicative/EagerApplicative.java
@@ -10,7 +10,7 @@ import com.aol.cyclops.types.ConvertableFunctor;
 import com.aol.cyclops.types.Functor;
 
 @FunctionalInterface
-public interface Applicative<T,R, D extends ConvertableFunctor<R>> 
+public interface EagerApplicative<T,R, D extends ConvertableFunctor<R>> 
                                     extends Functor<Function<? super T,? extends R>> {
 
     /**
@@ -27,7 +27,6 @@ public interface Applicative<T,R, D extends ConvertableFunctor<R>>
 		return delegate().map(fn);
 	}
 
-	//<U extends Functor<Function<? super T,? extends R>> & Convertable<Function<? super T,? extends R>>> U delegate();
 	ConvertableFunctor<Function<? super T,? extends R>>  delegate();
 	
 	default D ap(ConvertableFunctor<T> f){

--- a/src/main/java/com/aol/cyclops/util/CompletableFutures.java
+++ b/src/main/java/com/aol/cyclops/util/CompletableFutures.java
@@ -53,8 +53,8 @@ public class CompletableFutures {
         return FutureW.schedule(delay, ex, t).getFuture();
     }
     
-    public static <T1,T2,R> CompletableFuture<R> ap(CompletableFuture<? extends T1> f, Value<? extends T2> v, BiFunction<? super T1,? super T2,? extends R> fn){
-        return narrow(FutureW.of(f).ap(v, fn).getFuture());
+    public static <T1,T2,R> CompletableFuture<R> combine(CompletableFuture<? extends T1> f, Value<? extends T2> v, BiFunction<? super T1,? super T2,? extends R> fn){
+        return narrow(FutureW.of(f).combine(v, fn).getFuture());
     }
     public static <T1,T2,R> CompletableFuture<R> zip(CompletableFuture<? extends T1> f, Iterable<? extends T2> v, BiFunction<? super T1,? super T2,? extends R> fn){
         return narrow(FutureW.of(f).zip(v, fn).getFuture());

--- a/src/main/java/com/aol/cyclops/util/Optionals.java
+++ b/src/main/java/com/aol/cyclops/util/Optionals.java
@@ -40,8 +40,8 @@ public class Optionals {
 	public static <T,R> Optional<R> accumulatePresent(CollectionX<Optional<T>> maybes,Function<? super T, R> mapper,Semigroup<R> reducer){
 		return sequencePresent(maybes).map(s->s.map(mapper).reduce(reducer.reducer()).get());
 	}
-	  public static <T1,T2,R> Optional<R> ap(Optional<? extends T1> f, Value<? extends T2> v, BiFunction<? super T1,? super T2,? extends R> fn){
-	        return narrow(Maybe.fromOptional(f).ap(v, fn).toOptional());
+	  public static <T1,T2,R> Optional<R> combine(Optional<? extends T1> f, Value<? extends T2> v, BiFunction<? super T1,? super T2,? extends R> fn){
+	        return narrow(Maybe.fromOptional(f).combine(v, fn).toOptional());
 	    }
 	    public static <T1,T2,R> Optional<R> zip(Optional<? extends T1> f, Iterable<? extends T2> v, BiFunction<? super T1,? super T2,? extends R> fn){
 	        return narrow(Maybe.fromOptional(f).zip(v, fn).toOptional());

--- a/src/test/java/com/aol/cyclops/control/Eval2Test.java
+++ b/src/test/java/com/aol/cyclops/control/Eval2Test.java
@@ -534,11 +534,11 @@ public class Eval2Test {
 	}
 	@Test
     public void testApEval() {
-        assertThat(just.ap(Eval.later(()->20),this::add),equalTo(Eval.now(30)));
+        assertThat(just.combine(Eval.later(()->20),this::add),equalTo(Eval.now(30)));
     }
 	@Test
 	public void testApEvalLazy(){
-	    assertTrue(Eval.later(()->10).ap(Eval.later(()->20),this::add) instanceof Later);
+	    assertTrue(Eval.later(()->10).combine(Eval.later(()->20),this::add) instanceof Later);
 	}
 	
 	@Test

--- a/src/test/java/com/aol/cyclops/control/FeatureToggleTest.java
+++ b/src/test/java/com/aol/cyclops/control/FeatureToggleTest.java
@@ -68,7 +68,7 @@ public class FeatureToggleTest {
 	@Test
     public void testApFeatureToggle() {
 	    
-        assertThat(just.ap(FeatureToggle.enable(20),this::add),equalTo(FeatureToggle.enable(30)));
+        assertThat(just.combine(FeatureToggle.enable(20),this::add),equalTo(FeatureToggle.enable(30)));
     }
    
     @Test

--- a/src/test/java/com/aol/cyclops/control/FutureWTest.java
+++ b/src/test/java/com/aol/cyclops/control/FutureWTest.java
@@ -77,7 +77,7 @@ public class FutureWTest {
 	@Test
     public void testApFeatureToggle() {
         
-        assertThat(just.ap(FeatureToggle.enable(20),this::add).get(),equalTo(30));
+        assertThat(just.combine(FeatureToggle.enable(20),this::add).get(),equalTo(30));
     }
    
    
@@ -93,7 +93,7 @@ public class FutureWTest {
 	public void apNonBlocking(){
 	    
 	  val f =  FutureW.ofSupplier(()->{ sleep(1000l); return "hello";},ex)
-	            	  .ap(FutureW.ofSupplier(()->" world",ex),String::concat);
+	            	  .combine(FutureW.ofSupplier(()->" world",ex),String::concat);
 	  
 	  
 	  System.out.println("hello");

--- a/src/test/java/com/aol/cyclops/control/Ior2Test.java
+++ b/src/test/java/com/aol/cyclops/control/Ior2Test.java
@@ -59,7 +59,7 @@ public class Ior2Test {
 	@Test
     public void testApFeatureToggle() {
 	  
-        assertThat(just.ap(FeatureToggle.enable(20),this::add).get(),equalTo(30));
+        assertThat(just.combine(FeatureToggle.enable(20),this::add).get(),equalTo(30));
     }
    
     

--- a/src/test/java/com/aol/cyclops/control/Ior2Test.java
+++ b/src/test/java/com/aol/cyclops/control/Ior2Test.java
@@ -99,9 +99,9 @@ public class Ior2Test {
     }
     @Test
     public void visitIor(){
-        assertThat(just.visitIor(secondary->"no", primary->"yes"),equalTo(Ior.primary("yes")));
-        assertThat(none.visitIor(secondary->"no", primary->"yes"),equalTo(Ior.secondary("no")));
-        assertThat(Ior.both(10, "eek").visitIor(secondary->"no", primary->"yes"),equalTo(Ior.both("no","yes")));
+        assertThat(just.mapBoth(secondary->"no", primary->"yes"),equalTo(Ior.primary("yes")));
+        assertThat(none.mapBoth(secondary->"no", primary->"yes"),equalTo(Ior.secondary("no")));
+        assertThat(Ior.both(10, "eek").mapBoth(secondary->"no", primary->"yes"),equalTo(Ior.both("no","yes")));
     }
 	@Test
 	public void testToMaybe() {

--- a/src/test/java/com/aol/cyclops/control/MaybeTest.java
+++ b/src/test/java/com/aol/cyclops/control/MaybeTest.java
@@ -57,6 +57,7 @@ public class MaybeTest implements Printable {
 	public void setUp() throws Exception {
 		just = Maybe.of(10);
 		none = Maybe.none();
+		just.toLazyImmutable().visit(present, absent)
 	}
 	  @Test
       public void testApFeatureToggle() {

--- a/src/test/java/com/aol/cyclops/control/MaybeTest.java
+++ b/src/test/java/com/aol/cyclops/control/MaybeTest.java
@@ -61,7 +61,7 @@ public class MaybeTest implements Printable {
 	  @Test
       public void testApFeatureToggle() {
         
-          assertThat(just.ap(FeatureToggle.enable(20),this::add).get(),equalTo(30));
+          assertThat(just.combine(FeatureToggle.enable(20),this::add).get(),equalTo(30));
       }
      
      

--- a/src/test/java/com/aol/cyclops/control/MaybeTest.java
+++ b/src/test/java/com/aol/cyclops/control/MaybeTest.java
@@ -57,7 +57,7 @@ public class MaybeTest implements Printable {
 	public void setUp() throws Exception {
 		just = Maybe.of(10);
 		none = Maybe.none();
-		just.toLazyImmutable().visit(present, absent)
+		
 	}
 	  @Test
       public void testApFeatureToggle() {

--- a/src/test/java/com/aol/cyclops/control/TryTest.java
+++ b/src/test/java/com/aol/cyclops/control/TryTest.java
@@ -60,7 +60,7 @@ public class TryTest {
 	   @Test
 	    public void testApFeatureToggle() {
 	      
-	        assertThat(just.ap(FeatureToggle.enable(20),this::add).get(),equalTo(30));
+	        assertThat(just.combine(FeatureToggle.enable(20),this::add).get(),equalTo(30));
 	    }
 	   
 	    

--- a/src/test/java/com/aol/cyclops/control/Xor2Test.java
+++ b/src/test/java/com/aol/cyclops/control/Xor2Test.java
@@ -56,7 +56,7 @@ public class Xor2Test {
 	@Test
     public void testApFeatureToggle() {
       
-        assertThat(just.ap(FeatureToggle.enable(20),this::add).get(),equalTo(30));
+        assertThat(just.combine(FeatureToggle.enable(20),this::add).get(),equalTo(30));
     }
    
     

--- a/src/test/java/com/aol/cyclops/control/Xor2Test.java
+++ b/src/test/java/com/aol/cyclops/control/Xor2Test.java
@@ -95,8 +95,8 @@ public class Xor2Test {
 	}
 	@Test
     public void visitXor(){
-        assertThat(just.visitXor(secondary->"no", primary->"yes"),equalTo(Xor.primary("yes")));
-        assertThat(none.visitXor(secondary->"no", primary->"yes"),equalTo(Xor.secondary("no")));
+        assertThat(just.mapBoth(secondary->"no", primary->"yes"),equalTo(Xor.primary("yes")));
+        assertThat(none.mapBoth(secondary->"no", primary->"yes"),equalTo(Xor.secondary("no")));
     }
 	@Test
 	public void testToMaybe() {

--- a/src/test/java/com/aol/cyclops/control/XorTest.java
+++ b/src/test/java/com/aol/cyclops/control/XorTest.java
@@ -89,19 +89,19 @@ public class XorTest {
 	@Test
 	public void applicative(){
 	    Xor<String,String> fail1 =  Xor.secondary("failed1");
-	    Xor<String,String> result = fail1.ap(Xor.secondary("failed2"), Semigroups.stringConcat,(a,b)->a+b);
+	    Xor<String,String> result = fail1.combine(Xor.secondary("failed2"), Semigroups.stringConcat,(a,b)->a+b);
 	    assertThat(result.secondaryGet(),equalTo("failed2failed1"));
 	}
 	@Test
     public void applicativeColleciton(){
         Xor<String,String> fail1 =  Xor.secondary("failed1");
-        Xor<PStackX<String>,String> result = fail1.list().ap(Xor.secondary("failed2").list(), Semigroups.collectionXConcat(),(a,b)->a+b);
+        Xor<PStackX<String>,String> result = fail1.list().combine(Xor.secondary("failed2").list(), Semigroups.collectionXConcat(),(a,b)->a+b);
         assertThat(result.secondaryGet(),equalTo(PStackX.of("failed1","failed2")));
     }
 	@Test
     public void applicativePStack(){
         Xor<String,String> fail1 =  Xor.secondary("failed1");
-        Xor<PStackX<String>,String> result = fail1.apToList(Xor.<String,String>secondary("failed2"),(a,b)->a+b);
+        Xor<PStackX<String>,String> result = fail1.combineToList(Xor.<String,String>secondary("failed2"),(a,b)->a+b);
         assertThat(result.secondaryGet(),equalTo(PStackX.of("failed1","failed2")));
     }
 	

--- a/src/test/java/com/aol/cyclops/lambda/monads/AnyMTest.java
+++ b/src/test/java/com/aol/cyclops/lambda/monads/AnyMTest.java
@@ -38,7 +38,7 @@ import reactor.core.publisher.Flux;
 public class AnyMTest {
     @Test
     public void testApEval() {
-        assertThat(AnyM.fromEval(Eval.now(10)).ap(Eval.later(()->20),this::add).unwrap(),equalTo(Eval.now(30)));
+        assertThat(AnyM.fromEval(Eval.now(10)).combine(Eval.later(()->20),this::add).unwrap(),equalTo(Eval.now(30)));
     }
     @Test
     public void anyMSetConversion() {


### PR DESCRIPTION
More intuitive name for most Java developers. applyFunctions builder will still use ap()