### PR TITLE
MapX onEmpty

### DIFF
--- a/src/main/java/com/aol/cyclops/data/collections/extensions/persistent/PMapX.java
+++ b/src/main/java/com/aol/cyclops/data/collections/extensions/persistent/PMapX.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.jooq.lambda.Collectable;
@@ -13,6 +14,7 @@ import org.jooq.lambda.tuple.Tuple2;
 import org.pcollections.HashTreePMap;
 import org.pcollections.PMap;
 
+import com.aol.cyclops.control.Matchable.CheckValue1;
 import com.aol.cyclops.control.ReactiveSeq;
 import com.aol.cyclops.control.Trampoline;
 import com.aol.cyclops.data.collections.extensions.FluentMapX;
@@ -84,7 +86,7 @@ public interface PMapX<K, V> extends PMap<K, V>,
 
 	@Override
 	default ReactiveSeq<Tuple2<K, V>> stream() {
-		// TODO Auto-generated method stub
+		b
 		return ExtendedTraversable.super.stream();
 	}
 
@@ -110,7 +112,7 @@ public interface PMapX<K, V> extends PMap<K, V>,
 	 */
 	@Override
 	default PMapX<K, V> bipeek(Consumer<? super K> c1, Consumer<? super V> c2) {
-		// TODO Auto-generated method stub
+		b
 		return (PMapX<K, V>)BiFunctor.super.bipeek(c1, c2);
 	}
 
@@ -119,7 +121,7 @@ public interface PMapX<K, V> extends PMap<K, V>,
 	 */
 	@Override
 	default <U1, U2> PMapX<U1, U2> bicast(Class<U1> type1, Class<U2> type2) {
-		// TODO Auto-generated method stub
+		b
 		return (PMapX<U1, U2>)BiFunctor.super.bicast(type1, type2);
 	}
 
@@ -229,6 +231,15 @@ public interface PMapX<K, V> extends PMap<K, V>,
 		
 		return (PMapX<K, V>)IterableFilterable.super.retainAll(values);
 	}
+    /* (non-Javadoc)
+     * @see com.aol.cyclops.types.Functor#patternMatch(java.util.function.Function, java.util.function.Supplier)
+     */
+    @Override
+    default <R> PMapX<K,R> patternMatch(Function<CheckValue1<V, R>, CheckValue1<V, R>> case1,
+            Supplier<? extends R> otherwise) {
+        
+        return (PMapX<K,R>)Functor.super.patternMatch(case1, otherwise);
+    }
 	
 
 	

--- a/src/main/java/com/aol/cyclops/data/collections/extensions/standard/MapX.java
+++ b/src/main/java/com/aol/cyclops/data/collections/extensions/standard/MapX.java
@@ -11,6 +11,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -19,6 +20,7 @@ import org.jooq.lambda.Collectable;
 import org.jooq.lambda.tuple.Tuple;
 import org.jooq.lambda.tuple.Tuple2;
 
+import com.aol.cyclops.control.Matchable.CheckValue1;
 import com.aol.cyclops.control.ReactiveSeq;
 import com.aol.cyclops.control.Trampoline;
 import com.aol.cyclops.data.collections.extensions.FluentMapX;
@@ -270,6 +272,40 @@ public interface 	MapX<K,V> extends Map<K, V>, FluentMapX<K,V>,
 
 		return (MapX<K, V>)IterableFilterable.super.retainAll(values);
 	}
+    /* (non-Javadoc)
+     * @see com.aol.cyclops.types.Functor#patternMatch(java.util.function.Function, java.util.function.Supplier)
+     */
+    @Override
+    default <R> MapX<K,R> patternMatch(Function<CheckValue1<V, R>, CheckValue1<V, R>> case1,
+            Supplier<? extends R> otherwise) {
+       
+        return (MapX<K,R>)Functor.super.patternMatch(case1, otherwise);
+    }
+    /* (non-Javadoc)
+     * @see com.aol.cyclops.types.BiFunctor#bipeek(java.util.function.Consumer, java.util.function.Consumer)
+     */
+    @Override
+    default MapX<K, V> bipeek(Consumer<? super K> c1, Consumer<? super V> c2) {
+        
+        return (MapX<K, V>)BiFunctor.super.bipeek(c1, c2);
+    }
+    /* (non-Javadoc)
+     * @see com.aol.cyclops.types.BiFunctor#bicast(java.lang.Class, java.lang.Class)
+     */
+    @Override
+    default <U1, U2> MapX<U1, U2> bicast(Class<U1> type1, Class<U2> type2) {
+       
+        return (MapX<U1, U2>)BiFunctor.super.bicast(type1, type2);
+    }
+    /* (non-Javadoc)
+     * @see com.aol.cyclops.types.BiFunctor#bitrampoline(java.util.function.Function, java.util.function.Function)
+     */
+    @Override
+    default <R1, R2> MapX<R1, R2> bitrampoline(Function<? super K, ? extends Trampoline<? extends R1>> mapper1,
+            Function<? super V, ? extends Trampoline<? extends R2>> mapper2) {
+        
+        return (MapX<R1, R2>)BiFunctor.super.bitrampoline(mapper1, mapper2);
+    }
 
 
 

--- a/src/main/java/com/aol/cyclops/types/ExtendedTraversable.java
+++ b/src/main/java/com/aol/cyclops/types/ExtendedTraversable.java
@@ -13,11 +13,11 @@ public interface ExtendedTraversable<T> extends Traversable<T>,
 	
 	
 	/**
-	 * Generate the permutations based on values in the SequenceM Makes use of
+	 * Generate the permutations based on values in the ReactiveSeq Makes use of
 	 * Streamable to store intermediate stages in a collection
 	 * 
 	 * 
-	 * @return Permutations from this SequenceM
+	 * @return Permutations from this ReactiveSeq
 	 */
 	 default ExtendedTraversable<ReactiveSeq<T>> permutations(){
 		 return stream().permutations();
@@ -29,7 +29,7 @@ public interface ExtendedTraversable<T> extends Traversable<T>,
 	 * {@code
 	 *   ReactiveSeq.of(1,2,3).combinations(2)
 	 *   
-	 *   //SequenceM[SequenceM[1,2],SequenceM[1,3],SequenceM[2,3]]
+	 *   //ReactiveSeq[ReactiveSeq[1,2],ReactiveSeq[1,3],ReactiveSeq[2,3]]
 	 * }
 	 * </pre>
 	 * 
@@ -48,8 +48,8 @@ public interface ExtendedTraversable<T> extends Traversable<T>,
 	 * {@code
 	 *   ReactiveSeq.of(1,2,3).combinations()
 	 *   
-	 *   //SequenceM[SequenceM[],SequenceM[1],SequenceM[2],SequenceM[3].SequenceM[1,2],SequenceM[1,3],SequenceM[2,3]
-	 *   			,SequenceM[1,2,3]]
+	 *   //ReactiveSeq[ReactiveSeq[],ReactiveSeq[1],ReactiveSeq[2],ReactiveSeq[3].ReactiveSeq[1,2],ReactiveSeq[1,3],ReactiveSeq[2,3]
+	 *   			,ReactiveSeq[1,2,3]]
 	 * }
 	 * </pre>
 	 * 

--- a/src/main/java/com/aol/cyclops/types/OnEmpty.java
+++ b/src/main/java/com/aol/cyclops/types/OnEmpty.java
@@ -1,0 +1,38 @@
+package com.aol.cyclops.types;
+
+import java.util.function.Supplier;
+
+/**
+ * Represents a container that may be empty
+ * 
+ * @author johnmcclean
+ *
+ * @param <T> container type
+ */
+public interface OnEmpty<T> {
+   
+    /**
+     * If this Container instance is empty, create a new instance containing the provided value
+     * 
+     * @param value 
+     * @return New instance containing value if container is empty, otherwise returns this container
+     */
+    OnEmpty<T> onEmpty(T value);
+    
+    /**
+     * If this Container instance is empty, create a new instance containing the value returned from the provided Supplier
+     * 
+     * @param supplier to determine new value for container
+     * @return New Container with value if this is empty, otherwise this container
+     */
+    OnEmpty<T> onEmptyGet(Supplier<? extends T> supplier);
+    
+    /**
+     * If this container instance is empty, throw the exception returned by the provided Supplier
+     * 
+     * @param supplier to create exception from
+     * @return Throw exception if empty, otherwise this container
+     */
+    <X extends Throwable> OnEmpty<T> onEmptyThrow(Supplier<? extends X> supplier);
+   
+}

--- a/src/main/java/com/aol/cyclops/types/Traversable.java
+++ b/src/main/java/com/aol/cyclops/types/Traversable.java
@@ -28,7 +28,8 @@ import com.aol.cyclops.types.stream.lazy.LazyOperations;
 
 
 public interface Traversable<T> extends Iterable<T>, 
-                                        Publisher<T>{
+                                        Publisher<T>,
+                                        OnEmpty<T>{
 	
   
     default ReactiveSeq<T> stream(){

--- a/src/test/java/com/aol/cyclops/functions/collections/extensions/persistent/PMapXsTest.java
+++ b/src/test/java/com/aol/cyclops/functions/collections/extensions/persistent/PMapXsTest.java
@@ -6,11 +6,26 @@ import static org.junit.Assert.assertThat;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jooq.lambda.tuple.Tuple;
 import org.junit.Test;
 
+import com.aol.cyclops.data.collections.extensions.persistent.PMapX;
 import com.aol.cyclops.data.collections.extensions.persistent.PMapXs;
+import com.aol.cyclops.data.collections.extensions.standard.MapX;
 public class PMapXsTest {
 
+    @Test
+    public void onEmpty(){
+        assertThat(PMapX.empty().onEmpty(Tuple.tuple("hello",10)).get("hello"),equalTo(10));
+    }
+    @Test
+    public void onEmptyGet(){
+        assertThat(PMapX.empty().onEmptyGet(()->Tuple.tuple("hello",10)).get("hello"),equalTo(10));
+    }
+    @Test(expected=RuntimeException.class)
+    public void onEmptyThrow(){
+       PMapX.empty().onEmptyThrow(()->new RuntimeException("hello"));
+    }
     @Test
     public void testOf() {
         assertThat(PMapXs.of(),equalTo(new HashMap()));

--- a/src/test/java/com/aol/cyclops/functions/collections/extensions/standard/MapXsTest.java
+++ b/src/test/java/com/aol/cyclops/functions/collections/extensions/standard/MapXsTest.java
@@ -6,11 +6,25 @@ import static org.junit.Assert.assertThat;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jooq.lambda.tuple.Tuple;
 import org.junit.Test;
 
+import com.aol.cyclops.data.collections.extensions.standard.MapX;
 import com.aol.cyclops.data.collections.extensions.standard.MapXs;
 public class MapXsTest {
 
+    @Test
+    public void onEmpty(){
+        assertThat(MapX.empty().onEmpty(Tuple.tuple("hello",10)).get("hello"),equalTo(10));
+    }
+    @Test
+    public void onEmptyGet(){
+        assertThat(MapX.empty().onEmptyGet(()->Tuple.tuple("hello",10)).get("hello"),equalTo(10));
+    }
+    @Test(expected=RuntimeException.class)
+    public void onEmptyThrow(){
+       MapX.empty().onEmptyThrow(()->new RuntimeException("hello"));
+    }
     @Test
     public void testOf() {
         assertThat(MapXs.of(),equalTo(new HashMap()));


### PR DESCRIPTION
Remove Traversable as an implemented interface.

Create an OnEmpty interface, and implement onEmpty, onEmptyGet, onEmptyThrow for MapX and PMapX