### PR TITLE
Fix sleeping in FluentFunctions retry

### DIFF
--- a/src/main/java/cyclops/function/FluentFunctions.java
+++ b/src/main/java/cyclops/function/FluentFunctions.java
@@ -464,7 +464,8 @@ public class FluentFunctions {
                     } catch (final Throwable e) {
                         exception = e;
                     }
-                    ExceptionSoftener.softenRunnable(() -> Thread.sleep(sleep.get()));
+                    ExceptionSoftener.softenRunnable(() -> Thread.sleep(sleep.get()))
+                            .run();
 
                     sleep.mutate(s -> s * 2);
                 }


### PR DESCRIPTION
Updates FluentFunctions.retry to call the sleep
runnable so the call actually sleeps.

Fixes #475 

I couldn't find a good way to write a test for this scenario as it wouldn't be very deterministic unless I made the retry time longer and diff'd the start and end times.