### PR TITLE
Override Traversable#combine to accept a Monoid

### DIFF
--- a/src/main/java/com/aol/cyclops2/types/Traversable.java
+++ b/src/main/java/com/aol/cyclops2/types/Traversable.java
@@ -87,11 +87,38 @@ public interface Traversable<T> extends Publisher<T>,
      * 
      * @param predicate Test to see if two neighbours should be joined. The first parameter to the bi-predicate is the currently
      *                  accumulated result and the second is the next element
-     * @param op Reducer to combine neighbours
+     * @param op BinaryOperator to combine neighbours
      * @return Combined / Partially Reduced Traversable
      */
     default Traversable<T> combine(final BiPredicate<? super T, ? super T> predicate, final BinaryOperator<T> op) {
         return traversable().combine(predicate, op);
+    }
+
+    /**
+     * Combine two adjacent elements in a traversable using the supplied BinaryOperator
+     * This is a stateful grouping and reduction operation. The emitted of a combination may in turn be combined
+     * with it's neighbour
+     * <pre>
+     * {@code
+     *  ReactiveSeq.of(1,1,2,3)
+                  .combine(Monoids.intMult,(a, b)->a.equals(b))
+                  .toListX()
+
+     *  //ListX(1)
+     * }</pre>
+     *
+     * Simalar to @see {@link Traversable#combine(BiPredicate, BinaryOperator)} but differs in that the first comparison is always to the Monoid zero
+     * This allows us to terminate with just a single value
+     *
+     * @param predicate Test to see if two neighbours should be joined. The first parameter to the bi-predicate is the currently
+     *                  accumulated result and the second is the next element
+     * @param op Monoid to combine neighbours
+     * @return Combined / Partially Reduced Traversable
+     */
+    default Traversable<T> combine(final Monoid<T> op,final BiPredicate<? super T, ? super T> predicate) {
+
+        return prepend(op.zero()).traversable()
+                                 .combine(predicate, op);
     }
 
     /**

--- a/src/main/java/com/aol/cyclops2/types/anyM/AnyMSeq.java
+++ b/src/main/java/com/aol/cyclops2/types/anyM/AnyMSeq.java
@@ -596,6 +596,10 @@ public interface AnyMSeq<W extends WitnessType<W>,T> extends AnyM<W,T>, Foldable
 
         return fromIterable(FoldableTraversable.super.combine(predicate, op));
     }
+    @Override
+    default AnyMSeq<W,T> combine(final Monoid<T> op, final BiPredicate<? super T, ? super T> predicate) {
+        return (AnyMSeq<W,T>)FoldableTraversable.super.combine(op,predicate);
+    }
 
     /* (non-Javadoc)
      * @see com.aol.cyclops2.types.Traversable#groupedWhile(java.util.function.Predicate)

--- a/src/main/java/com/aol/cyclops2/types/anyM/transformers/TransformerSeq.java
+++ b/src/main/java/com/aol/cyclops2/types/anyM/transformers/TransformerSeq.java
@@ -137,6 +137,7 @@ public interface TransformerSeq<W extends WitnessType<W>,T> extends Unwrapable,
         return unitAnyM(transformerStream().map(s -> s.combine(predicate, op)));
     }
 
+
     /* (non-Javadoc)
      * @see com.aol.cyclops2.types.Traversable#subscribeAll(org.reactivestreams.Subscriber)
      */

--- a/src/main/java/cyclops/collections/DequeX.java
+++ b/src/main/java/cyclops/collections/DequeX.java
@@ -1,8 +1,10 @@
 package cyclops.collections;
 
+import com.aol.cyclops2.data.collections.extensions.CollectionX;
 import com.aol.cyclops2.data.collections.extensions.lazy.LazyDequeX;
 import com.aol.cyclops2.data.collections.extensions.standard.MutableCollectionX;
 import com.aol.cyclops2.hkt.Higher;
+import com.aol.cyclops2.types.FoldableTraversable;
 import cyclops.CyclopsCollectors;
 import cyclops.collections.immutable.PVectorX;
 import cyclops.function.Monoid;
@@ -400,6 +402,11 @@ public interface DequeX<T> extends To<DequeX<T>>,
     @Override
     default DequeX<T> combine(final BiPredicate<? super T, ? super T> predicate, final BinaryOperator<T> op) {
         return (DequeX<T>) MutableCollectionX.super.combine(predicate, op);
+    }
+
+    @Override
+    default DequeX<T> combine(final Monoid<T> op, final BiPredicate<? super T, ? super T> predicate) {
+        return (DequeX<T>)MutableCollectionX.super.combine(op,predicate);
     }
 
     /**

--- a/src/main/java/cyclops/collections/ListX.java
+++ b/src/main/java/cyclops/collections/ListX.java
@@ -747,6 +747,11 @@ public interface ListX<T> extends To<ListX<T>>,
         return (ListX<T>) MutableCollectionX.super.combine(predicate, op);
     }
 
+    @Override
+    default ListX<T> combine(final Monoid<T> op, final BiPredicate<? super T, ? super T> predicate) {
+        return (ListX<T>)MutableCollectionX.super.combine(op,predicate);
+    }
+
     /* (non-Javadoc)
      * @see com.aol.cyclops2.collections.extensions.standard.MutableCollectionX#filter(java.util.function.Predicate)
      */

--- a/src/main/java/cyclops/collections/QueueX.java
+++ b/src/main/java/cyclops/collections/QueueX.java
@@ -368,6 +368,10 @@ public interface QueueX<T> extends To<QueueX<T>>,Queue<T>,
     default QueueX<T> combine(final BiPredicate<? super T, ? super T> predicate, final BinaryOperator<T> op) {
         return (QueueX<T>) MutableCollectionX.super.combine(predicate, op);
     }
+    @Override
+    default QueueX<T> combine(final Monoid<T> op, final BiPredicate<? super T, ? super T> predicate) {
+        return (QueueX<T>)MutableCollectionX.super.combine(op,predicate);
+    }
 
     @Override
     default <R> QueueX<R> unit(final Collection<R> col) {

--- a/src/main/java/cyclops/collections/SetX.java
+++ b/src/main/java/cyclops/collections/SetX.java
@@ -304,6 +304,10 @@ public interface SetX<T> extends To<SetX<T>>,Set<T>, MutableCollectionX<T>, OnEm
     default SetX<T> combine(final BiPredicate<? super T, ? super T> predicate, final BinaryOperator<T> op) {
         return (SetX<T>) MutableCollectionX.super.combine(predicate, op);
     }
+    @Override
+    default SetX<T> combine(final Monoid<T> op, final BiPredicate<? super T, ? super T> predicate) {
+        return (SetX<T>)MutableCollectionX.super.combine(op,predicate);
+    }
 
     /* (non-Javadoc)
      * @see com.aol.cyclops2.sequence.traits.ConvertableSequence#toListX()

--- a/src/main/java/cyclops/collections/SortedSetX.java
+++ b/src/main/java/cyclops/collections/SortedSetX.java
@@ -311,7 +311,10 @@ public interface SortedSetX<T> extends To<SortedSetX<T>>,SortedSet<T>, MutableCo
     default SortedSetX<T> combine(final BiPredicate<? super T, ? super T> predicate, final BinaryOperator<T> op) {
         return (SortedSetX<T>) MutableCollectionX.super.combine(predicate, op);
     }
-   
+    @Override
+    default SortedSetX<T> combine(final Monoid<T> op, final BiPredicate<? super T, ? super T> predicate) {
+        return (SortedSetX<T>)MutableCollectionX.super.combine(op,predicate);
+    }
     @Override
     default <R> SortedSetX<R> unit(final R value) {
         return singleton(value);

--- a/src/main/java/cyclops/collections/immutable/PBagX.java
+++ b/src/main/java/cyclops/collections/immutable/PBagX.java
@@ -327,6 +327,10 @@ public interface PBagX<T> extends To<PBagX<T>>,PBag<T>, PersistentCollectionX<T>
     default PBagX<T> combine(final BiPredicate<? super T, ? super T> predicate, final BinaryOperator<T> op) {
         return (PBagX<T>) PersistentCollectionX.super.combine(predicate, op);
     }
+    @Override
+    default PBagX<T> combine(final Monoid<T> op, final BiPredicate<? super T, ? super T> predicate) {
+        return (PBagX<T>)PersistentCollectionX.super.combine(op,predicate);
+    }
 
     /* (non-Javadoc)
      * @see com.aol.cyclops2.sequence.traits.ConvertableSequence#toListX()

--- a/src/main/java/cyclops/collections/immutable/POrderedSetX.java
+++ b/src/main/java/cyclops/collections/immutable/POrderedSetX.java
@@ -360,7 +360,11 @@ public interface POrderedSetX<T> extends To<POrderedSetX<T>>,POrderedSet<T>, Per
     @Override
     default POrderedSetX<T> combine(final BiPredicate<? super T, ? super T> predicate, final BinaryOperator<T> op) {
         return (POrderedSetX<T>) PersistentCollectionX.super.combine(predicate, op);
-    }  
+    }
+    @Override
+    default POrderedSetX<T> combine(final Monoid<T> op, final BiPredicate<? super T, ? super T> predicate) {
+        return (POrderedSetX<T>)PersistentCollectionX.super.combine(op,predicate);
+    }
 
 
     @Override

--- a/src/main/java/cyclops/collections/immutable/PQueueX.java
+++ b/src/main/java/cyclops/collections/immutable/PQueueX.java
@@ -361,6 +361,10 @@ public interface PQueueX<T> extends To<PQueueX<T>>,
     default PQueueX<T> combine(final BiPredicate<? super T, ? super T> predicate, final BinaryOperator<T> op) {
         return (PQueueX<T>) PersistentCollectionX.super.combine(predicate, op);
     }
+    @Override
+    default PQueueX<T> combine(final Monoid<T> op, final BiPredicate<? super T, ? super T> predicate) {
+        return (PQueueX<T>)PersistentCollectionX.super.combine(op,predicate);
+    }
 
 
     @Override

--- a/src/main/java/cyclops/collections/immutable/PSetX.java
+++ b/src/main/java/cyclops/collections/immutable/PSetX.java
@@ -306,7 +306,10 @@ public interface PSetX<T> extends To<PSetX<T>>,PSet<T>, PersistentCollectionX<T>
     default PSetX<T> combine(final BiPredicate<? super T, ? super T> predicate, final BinaryOperator<T> op) {
         return (PSetX<T>) PersistentCollectionX.super.combine(predicate, op);
     }
-
+    @Override
+    default PSetX<T> combine(final Monoid<T> op, final BiPredicate<? super T, ? super T> predicate) {
+        return (PSetX<T>)PersistentCollectionX.super.combine(op,predicate);
+    }
     @Override
     default <R> PSetX<R> unit(final Collection<R> col) {
         return fromCollection(col);

--- a/src/main/java/cyclops/collections/immutable/PStackX.java
+++ b/src/main/java/cyclops/collections/immutable/PStackX.java
@@ -458,6 +458,11 @@ public interface PStackX<T> extends To<PStackX<T>>,
     default PStackX<T> combine(final BiPredicate<? super T, ? super T> predicate, final BinaryOperator<T> op) {
         return (PStackX<T>) PersistentCollectionX.super.combine(predicate, op);
     }
+
+    @Override
+    default PStackX<T> combine(final Monoid<T> op, final BiPredicate<? super T, ? super T> predicate) {
+        return (PStackX<T>)PersistentCollectionX.super.combine(op,predicate);
+    }
     
 
 

--- a/src/main/java/cyclops/collections/immutable/PVectorX.java
+++ b/src/main/java/cyclops/collections/immutable/PVectorX.java
@@ -341,6 +341,10 @@ public interface PVectorX<T> extends To<PVectorX<T>>,
         return (PVectorX<T>) PersistentCollectionX.super.combine(predicate, op);
     }
     @Override
+    default PVectorX<T> combine(final Monoid<T> op, final BiPredicate<? super T, ? super T> predicate) {
+        return (PVectorX<T>)PersistentCollectionX.super.combine(op,predicate);
+    }
+    @Override
     default PVectorX<T> materialize() {
         return (PVectorX<T>)PersistentCollectionX.super.materialize();
     }

--- a/src/main/java/cyclops/monads/transformers/ListT.java
+++ b/src/main/java/cyclops/monads/transformers/ListT.java
@@ -11,6 +11,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
 
+import com.aol.cyclops2.data.collections.extensions.standard.MutableCollectionX;
 import cyclops.control.Maybe;
 import com.aol.cyclops2.types.FoldableTraversable;
 import cyclops.function.Fn3;
@@ -346,6 +347,10 @@ public class ListT<W extends WitnessType<W>,T> implements To<ListT<W,T>>,
     public ListT<W,T> combine(final BiPredicate<? super T, ? super T> predicate, final BinaryOperator<T> op) {
 
         return (ListT<W,T>) FoldableTransformerSeq.super.combine(predicate, op);
+    }
+    @Override
+    public ListT<W,T> combine(final Monoid<T> op, final BiPredicate<? super T, ? super T> predicate) {
+        return (ListT<W,T>)FoldableTransformerSeq.super.combine(op,predicate);
     }
 
     /* (non-Javadoc)

--- a/src/main/java/cyclops/monads/transformers/StreamT.java
+++ b/src/main/java/cyclops/monads/transformers/StreamT.java
@@ -296,7 +296,10 @@ public class StreamT<W extends WitnessType<W>,T> implements To<StreamT<W,T>>,
 
         return (StreamT<W,T>) FoldableTransformerSeq.super.combine(predicate, op);
     }
-
+    @Override
+    public StreamT<W,T> combine(final Monoid<T> op, final BiPredicate<? super T, ? super T> predicate) {
+        return (StreamT<W,T>)FoldableTransformerSeq.super.combine(op,predicate);
+    }
     /* (non-Javadoc)
      * @see cyclops2.monads.transformers.values.ListT#cycle(int)
      */

--- a/src/main/java/cyclops/stream/FutureStream.java
+++ b/src/main/java/cyclops/stream/FutureStream.java
@@ -523,7 +523,10 @@ public interface FutureStream<U> extends LazySimpleReactStream<U>,
     default FutureStream<U> combine(final BiPredicate<? super U, ? super U> predicate, final BinaryOperator<U> op) {
         return fromStream(Streams.combine(this, predicate, op));
     }
-
+    @Override
+    default FutureStream<U> combine(final Monoid<U> op, final BiPredicate<? super U, ? super U> predicate) {
+        return (FutureStream<U>)ReactiveSeq.super.combine(op,predicate);
+    }
     /**
      * If this SequenceM is empty replace it with a another Stream
      *

--- a/src/main/java/cyclops/stream/ReactiveSeq.java
+++ b/src/main/java/cyclops/stream/ReactiveSeq.java
@@ -1649,6 +1649,12 @@ public interface ReactiveSeq<T> extends To<ReactiveSeq<T>>,
         return fromStream(Streams.combine(this, predicate, op));
     }
 
+
+    @Override
+    default ReactiveSeq<T> combine(final Monoid<T> op, final BiPredicate<? super T, ? super T> predicate) {
+        return (ReactiveSeq<T>)FoldableTraversable.super.combine(op,predicate);
+    }
+
     /**
      * <pre>
      * {@code

--- a/src/main/java/cyclops/stream/Streamable.java
+++ b/src/main/java/cyclops/stream/Streamable.java
@@ -165,6 +165,10 @@ public interface Streamable<T> extends  To<Streamable<T>>,
 
         return Streamable.fromIterable(FoldableTraversable.super.combine(predicate, op));
     }
+    @Override
+    default Streamable<T> combine(final Monoid<T> op, final BiPredicate<? super T, ? super T> predicate) {
+        return (Streamable<T>)FoldableTraversable.super.combine(op,predicate);
+    }
 
     /* (non-Javadoc)
      * @see com.aol.cyclops2.types.Traversable#zip(java.lang.Iterable, java.util.function.BiFunction)

--- a/src/test/java/com/aol/cyclops2/control/ReactiveSeqTest.java
+++ b/src/test/java/com/aol/cyclops2/control/ReactiveSeqTest.java
@@ -3,6 +3,7 @@ package com.aol.cyclops2.control;
 import com.aol.cyclops2.types.stream.reactive.AsyncSubscriber;
 import com.aol.cyclops2.util.SimpleTimer;
 import com.google.common.collect.Lists;
+import cyclops.Monoids;
 import cyclops.Semigroups;
 import cyclops.collections.ListX;
 
@@ -53,6 +54,13 @@ import static org.junit.Assert.fail;
 public class ReactiveSeqTest {
     AtomicBoolean active = new AtomicBoolean(true);
 
+    @Test
+    public void testCombineMonoid(){
+        assertThat(ReactiveSeq.of(1,1,2,3)
+                .combine(Monoids.intMult,(a, b)->a.equals(b))
+                .findFirst().get()
+               , equalTo(1));
+    }
     @Test
     public void crossJoinTest(){
         assertThat(ReactiveSeq.of(1, 2)


### PR DESCRIPTION
This allows short circuiting after the evaluation of a single value.

impl for #382