### PR TITLE
Operations on LazySeq don't maintain lazyness - they eagerly fetch everything

### DIFF
--- a/src/test/java/cyclops/data/LazySeqTest.java
+++ b/src/test/java/cyclops/data/LazySeqTest.java
@@ -81,15 +81,11 @@ public class LazySeqTest extends BaseImmutableListTest {
 
 
   }
-  /**
-   * Test no maps are called before fetching values and map function only invoked once for each input.
-   *
-   * @throws Exception
-   */
+
   // TODO(johnmcclean): Stop ignoring this test
   @Ignore
   @Test
-  public void testLazy2() throws Exception {
+  public void testNoMapCalledBeforeFetchingAndOnlyOnceForEachInput() throws Exception {
     @SuppressWarnings("unchecked")
     Function<Integer, Integer> mockFunction = Mockito.mock(Function.class);
     Mockito.doAnswer(invocation -> {
@@ -116,15 +112,10 @@ public class LazySeqTest extends BaseImmutableListTest {
     inOrder.verifyNoMoreInteractions();
   }
 
-  /**
-   * Test that the first map is called before fetching all values and map function only invoked once for each input.
-   *
-   * @throws Exception
-   */
   // TODO(johnmcclean): Stop ignoring this test
   @Ignore
   @Test
-  public void testLazy3() throws Exception {
+  public void testFirstMapCalledBeforeFetchingOthersAfterAndAllMapsCalledOnlyOnce() throws Exception {
     @SuppressWarnings("unchecked")
     Function<Integer, Integer> mockFunction = Mockito.mock(Function.class);
     Mockito.doAnswer(invocation -> {

--- a/src/test/java/cyclops/data/LazySeqTest.java
+++ b/src/test/java/cyclops/data/LazySeqTest.java
@@ -93,7 +93,6 @@ public class LazySeqTest extends BaseImmutableListTest {
       return arg * 2;
     }).when(mockFunction).apply(anyInt());
 
-    @SuppressWarnings("Guava")
     LazySeq<Integer> result = LazySeq.of(1, 2, 3, 4, 5)
       .map(mockFunction);
 
@@ -123,7 +122,6 @@ public class LazySeqTest extends BaseImmutableListTest {
       return arg * 2;
     }).when(mockFunction).apply(anyInt());
 
-    @SuppressWarnings("Guava")
     LazySeq<Integer> result = LazySeq.of(1, 2, 3, 4, 5)
       .map(mockFunction);
 

--- a/src/test/java/cyclops/data/LazySeqTest.java
+++ b/src/test/java/cyclops/data/LazySeqTest.java
@@ -4,13 +4,16 @@ package cyclops.data;
 import com.oath.cyclops.types.traversable.IterableX;
 import cyclops.companion.Reducers;
 import cyclops.control.Option;
-import cyclops.data.tuple.Tuple2;
 import cyclops.data.basetests.BaseImmutableListTest;
+import cyclops.data.tuple.Tuple2;
 import cyclops.reactive.ReactiveSeq;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.function.Function;
@@ -19,10 +22,9 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyInt;
 
 public class LazySeqTest extends BaseImmutableListTest {
 
@@ -79,6 +81,76 @@ public class LazySeqTest extends BaseImmutableListTest {
 
 
   }
+  /**
+   * Test no maps are called before fetching values and map function only invoked once for each input.
+   *
+   * @throws Exception
+   */
+  // TODO(johnmcclean): Stop ignoring this test
+  @Ignore
+  @Test
+  public void testLazy2() throws Exception {
+    @SuppressWarnings("unchecked")
+    Function<Integer, Integer> mockFunction = Mockito.mock(Function.class);
+    Mockito.doAnswer(invocation -> {
+      int arg = (Integer) invocation.getArguments()[0];
+      return arg * 2;
+    }).when(mockFunction).apply(anyInt());
+
+    @SuppressWarnings("Guava")
+    LazySeq<Integer> result = LazySeq.of(1, 2, 3, 4, 5)
+      .map(mockFunction);
+
+    InOrder inOrder = Mockito.inOrder(mockFunction);
+    inOrder.verifyNoMoreInteractions();
+
+    // Invoke twice to assert function called only once
+    assertThat(result, hasItems(2, 4, 6, 8, 10));
+    assertThat(result, hasItems(2, 4, 6, 8, 10));
+
+    inOrder.verify(mockFunction).apply(1);
+    inOrder.verify(mockFunction).apply(2);
+    inOrder.verify(mockFunction).apply(3);
+    inOrder.verify(mockFunction).apply(4);
+    inOrder.verify(mockFunction).apply(5);
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  /**
+   * Test that the first map is called before fetching all values and map function only invoked once for each input.
+   *
+   * @throws Exception
+   */
+  // TODO(johnmcclean): Stop ignoring this test
+  @Ignore
+  @Test
+  public void testLazy3() throws Exception {
+    @SuppressWarnings("unchecked")
+    Function<Integer, Integer> mockFunction = Mockito.mock(Function.class);
+    Mockito.doAnswer(invocation -> {
+      int arg = (Integer) invocation.getArguments()[0];
+      return arg * 2;
+    }).when(mockFunction).apply(anyInt());
+
+    @SuppressWarnings("Guava")
+    LazySeq<Integer> result = LazySeq.of(1, 2, 3, 4, 5)
+      .map(mockFunction);
+
+    InOrder inOrder = Mockito.inOrder(mockFunction);
+    inOrder.verify(mockFunction).apply(1);
+    inOrder.verifyNoMoreInteractions();
+
+    // Invoke twice to assert function called only once
+    assertThat(result, hasItems(2, 4, 6, 8, 10));
+    assertThat(result, hasItems(2, 4, 6, 8, 10));
+
+    inOrder.verify(mockFunction).apply(2);
+    inOrder.verify(mockFunction).apply(3);
+    inOrder.verify(mockFunction).apply(4);
+    inOrder.verify(mockFunction).apply(5);
+    inOrder.verifyNoMoreInteractions();
+  }
+
   @Test
   public void mapLarge(){
     LazySeq.range(0,100_000_000).map(i->count++);


### PR DESCRIPTION
LazySeq may operate similar to Scala's stream inasmuch as it invokes the first thing, but when applying monad functions on it (map, flatMap), those methods should not be invoked until consumed if possible.  

Minimally, you could only map the first thing, but I would find it much more useful if LazySeq (or a LazySeq with transformations on it) operated more like Guava's `FluentIterable`, where none of the transformations happened until the call to one of `hasNext` or `next`.  I don't always want to use `ListX` because there are times that I just want an easy way to iterate across filtered/transformed data but not actually hold it all in memory.

See the tests added in this PR for examples of expected behavior that is not honored.